### PR TITLE
LPS-44481 Format source

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/edit_folder.jsp
+++ b/portal-web/docroot/html/portlet/document_library/edit_folder.jsp
@@ -31,9 +31,7 @@ long parentFolderId = BeanParamUtil.getLong(folder, request, "parentFolderId", D
 
 boolean rootFolder = ParamUtil.getBoolean(request, "rootFolder");
 
-boolean workflowEnabled = WorkflowEngineManagerUtil.isDeployed()
-                          && (WorkflowHandlerRegistryUtil.getWorkflowHandler(DLFileEntry.class.getName()) != null)
-                          && (DLPermission.contains(themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroupId(), ActionKeys.ADD_DOCUMENT) || DLPermission.contains(themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroupId(), ActionKeys.UPDATE));
+boolean workflowEnabled = WorkflowEngineManagerUtil.isDeployed() && (WorkflowHandlerRegistryUtil.getWorkflowHandler(DLFileEntry.class.getName()) != null) && DLFolderPermission.contains(permissionChecker, themeDisplay.getScopeGroupId(), folderId, ActionKeys.UPDATE);
 
 List<WorkflowDefinition> workflowDefinitions = null;
 


### PR DESCRIPTION
Hey @gallindo 

Can you please review my changes?

I used a different permission checking that I think it makes more sense. Basically, we are displaying the workflow definitions only when the user has permission to update the folder, because that's what the user is intending to do when rendering that jsp, right?

I didn't test the solution, so can you please test it and make sure that everything is working as expected and we I'm not introducing any regression?

Thx!
