### PR TITLE
LPS-65965 Document is listed in search results, while the user has no…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/DefaultSearchResultPermissionFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/DefaultSearchResultPermissionFilter.java
@@ -81,16 +81,15 @@ public class DefaultSearchResultPermissionFilter
 
 	@Override
 	protected boolean isGroupAdmin(SearchContext searchContext) {
-		long[] groupIds = searchContext.getGroupIds();
+		int groupId = GetterUtil.getInteger(
+			searchContext.getAttribute(Field.GROUP_ID));
 
-		if (groupIds == null) {
+		if (groupId == 0) {
 			return false;
 		}
 
-		for (long groupId : groupIds) {
-			if (!_permissionChecker.isGroupAdmin(groupId)) {
-				return false;
-			}
+		if (!_permissionChecker.isGroupAdmin(groupId)) {
+			return false;
 		}
 
 		return true;


### PR DESCRIPTION
… permission to view it.

This is a permissioning problem that only occurs when searching "everywhere".  The group admin check was only checking the groupId of the site the user was on.  The isGroupAdmin check should only return true when the search is scoped to a site.

I've asked for the LPS to be updated with steps.