### PR TITLE
[TS - FP4] LPS-73889 Pagination is not working in the search results in Users and Organizations with Solr: SolrIndexSearcher searchCount always returns zero when the main query ("q") is empty and there are filter queries ("fq") only

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexSearcherTestCase.java
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexSearcherTestCase.java
@@ -16,10 +16,14 @@ package com.liferay.portal.search.test.util.indexing;
 
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.IndexSearcher;
+import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
@@ -49,6 +53,32 @@ public abstract class BaseIndexSearcherTestCase extends BaseIndexingTestCase {
 					RandomTestUtil.randomString(
 						UniqueStringRandomizerBumper.INSTANCE)));
 		}
+	}
+
+	@Test
+	public void testCountWithEmptyMainQueryAndFilter() throws Exception {
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		booleanFilter.addRequiredTerm(Field.GROUP_ID, GROUP_ID);
+
+		Query booleanQuery = new BooleanQueryImpl();
+
+		booleanQuery.setPreBooleanFilter(booleanFilter);
+
+		IdempotentRetryAssert.retryAssert(
+			3, TimeUnit.SECONDS,
+			() -> {
+				IndexSearcher indexSearcher = getIndexSearcher();
+
+				SearchContext searchContext = createSearchContext();
+
+				long count = indexSearcher.searchCount(
+					searchContext, booleanQuery);
+
+				Assert.assertEquals(_TOTAL_DOCUMENTS, count);
+
+				return null;
+			});
 	}
 
 	@Test

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.search.facet.RangeFacet;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.search.filter.FilterTranslator;
+import com.liferay.portal.kernel.search.generic.MatchAllQuery;
 import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.search.query.QueryTranslator;
 import com.liferay.portal.kernel.search.suggest.QuerySuggester;
@@ -472,6 +473,13 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 		if (!filterQueries.isEmpty()) {
 			solrQuery.setFilterQueries(
 				filterQueries.toArray(new String[filterQueries.size()]));
+
+			if (Validator.isBlank(solrQuery.getQuery())) {
+				queryString = translateQuery(
+					new MatchAllQuery(), searchContext);
+
+				solrQuery.setQuery(queryString);
+			}
 		}
 
 		String solrQueryString = solrQuery.toString();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-73889

Hi André,

Alternatively, we could set the "filters" as "q" when the main query is empty.

Please prioritize this so this can be included in the next Solr release.

Thanks!
Tibor