### PR TITLE
LPS-77701 Move search result permission filter from core to portal-search

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/BaseSearchResultPermissionFilter.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/BaseSearchResultPermissionFilter.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.permission;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.HitsImpl;
+import com.liferay.portal.kernel.search.QueryConfig;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.search.SearchResultPermissionFilter;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Time;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Tina Tian
+ */
+public abstract class BaseSearchResultPermissionFilter
+	implements SearchResultPermissionFilter {
+
+	@Override
+	public Hits search(SearchContext searchContext) throws SearchException {
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		if (!queryConfig.isAllFieldsSelected()) {
+			Set<String> selectedFieldNameSet = SetUtil.fromArray(
+				queryConfig.getSelectedFieldNames());
+
+			Collections.addAll(
+				selectedFieldNameSet, _PERMISSION_SELECTED_FIELD_NAMES);
+
+			queryConfig.setSelectedFieldNames(
+				selectedFieldNameSet.toArray(
+					new String[selectedFieldNameSet.size()]));
+		}
+
+		int end = searchContext.getEnd();
+		int start = searchContext.getStart();
+
+		if ((end == QueryUtil.ALL_POS) && (start == QueryUtil.ALL_POS)) {
+			Hits hits = getHits(searchContext);
+
+			if (!isGroupAdmin(searchContext)) {
+				filterHits(hits, searchContext);
+			}
+
+			return hits;
+		}
+
+		if ((start < 0) || (start > end)) {
+			return new HitsImpl();
+		}
+
+		if (isGroupAdmin(searchContext)) {
+			return getHits(searchContext);
+		}
+
+		double amplificationFactor = 1.0;
+		int excludedDocsSize = 0;
+		int hitsSize = 0;
+		int offset = 0;
+		long startTime = 0;
+
+		List<Document> documents = new ArrayList<>();
+		List<Float> scores = new ArrayList<>();
+
+		while (true) {
+			int count = end - documents.size();
+
+			int amplifiedCount = (int)Math.ceil(count * amplificationFactor);
+
+			int amplifiedEnd = offset + amplifiedCount;
+
+			searchContext.setEnd(amplifiedEnd);
+
+			searchContext.setStart(offset);
+
+			Hits hits = getHits(searchContext);
+
+			if (startTime == 0) {
+				hitsSize = hits.getLength();
+				startTime = hits.getStart();
+			}
+
+			Document[] oldDocs = hits.getDocs();
+
+			filterHits(hits, searchContext);
+
+			Document[] newDocs = hits.getDocs();
+
+			excludedDocsSize += oldDocs.length - newDocs.length;
+
+			collectHits(hits, documents, scores, count);
+
+			if ((newDocs.length >= count) ||
+				(oldDocs.length < amplifiedCount) ||
+				(amplifiedEnd >= hitsSize)) {
+
+				updateHits(
+					hits, documents, scores, start, end,
+					hitsSize - excludedDocsSize, startTime);
+
+				return hits;
+			}
+
+			offset = amplifiedEnd;
+
+			amplificationFactor = _getAmplificationFactor(
+				documents.size(), offset);
+		}
+	}
+
+	protected void collectHits(
+		Hits hits, List<Document> documents, List<Float> scores, int count) {
+
+		Document[] docs = hits.getDocs();
+
+		if (docs.length < count) {
+			count = docs.length;
+		}
+
+		for (int i = 0; i < count; i++) {
+			documents.add(docs[i]);
+
+			scores.add(hits.score(i));
+		}
+	}
+
+	protected abstract void filterHits(Hits hits, SearchContext searchContext);
+
+	protected abstract Hits getHits(SearchContext searchContext)
+		throws SearchException;
+
+	protected abstract boolean isGroupAdmin(SearchContext searchContext);
+
+	protected void updateHits(
+		Hits hits, List<Document> documents, List<Float> scores, int start,
+		int end, int size, long startTime) {
+
+		int[] startAndEnd = SearchPaginationUtil.calculateStartAndEnd(
+			start, end, documents.size());
+
+		start = startAndEnd[0];
+		end = startAndEnd[1];
+
+		documents = documents.subList(start, end);
+		scores = scores.subList(start, end);
+
+		hits.setDocs(documents.toArray(new Document[documents.size()]));
+		hits.setScores(ArrayUtil.toFloatArray(scores));
+		hits.setLength(size);
+		hits.setSearchTime(
+			(float)(System.currentTimeMillis() - startTime) / Time.SECOND);
+	}
+
+	private double _getAmplificationFactor(double totalViewable, double total) {
+		if (totalViewable == 0) {
+			return _INDEX_PERMISSION_FILTER_SEARCH_AMPLIFICATION_FACTOR;
+		}
+
+		return Math.min(
+			1.0 / (totalViewable / total),
+			_INDEX_PERMISSION_FILTER_SEARCH_AMPLIFICATION_FACTOR);
+	}
+
+	private static final double
+		_INDEX_PERMISSION_FILTER_SEARCH_AMPLIFICATION_FACTOR =
+			GetterUtil.getDouble(
+				PropsUtil.get(
+					PropsKeys.
+						INDEX_PERMISSION_FILTER_SEARCH_AMPLIFICATION_FACTOR));
+
+	private static final String[] _PERMISSION_SELECTED_FIELD_NAMES =
+		{Field.COMPANY_ID, Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK};
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.permission;
+
+import aQute.bnd.annotation.ProviderType;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.RelatedEntryIndexer;
+import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistryUtil;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.FacetPostProcessor;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.ServiceProxyFactory;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Tina Tian
+ */
+@ProviderType
+public class DefaultSearchResultPermissionFilter
+	extends BaseSearchResultPermissionFilter {
+
+	public DefaultSearchResultPermissionFilter(
+		SearchExecutor searchExecutor, PermissionChecker permissionChecker) {
+
+		_searchExecutor = searchExecutor;
+		_permissionChecker = permissionChecker;
+	}
+
+	public interface SearchExecutor {
+
+		public Hits search(SearchContext searchContext) throws SearchException;
+
+	}
+
+	@Override
+	protected void filterHits(Hits hits, SearchContext searchContext) {
+		List<Document> docs = new ArrayList<>();
+		List<Document> excludeDocs = new ArrayList<>();
+		List<Float> scores = new ArrayList<>();
+
+		boolean companyAdmin = _permissionChecker.isCompanyAdmin(
+			_permissionChecker.getCompanyId());
+		int status = GetterUtil.getInteger(
+			searchContext.getAttribute(Field.STATUS),
+			WorkflowConstants.STATUS_APPROVED);
+
+		Document[] documents = hits.getDocs();
+
+		for (int i = 0; i < documents.length; i++) {
+			if (_isIncludeDocument(
+					documents[i], _permissionChecker.getCompanyId(),
+					companyAdmin, status)) {
+
+				docs.add(documents[i]);
+				scores.add(hits.score(i));
+			}
+			else {
+				excludeDocs.add(documents[i]);
+			}
+		}
+
+		if (!excludeDocs.isEmpty()) {
+			FacetPostProcessor facetPostProcessor = _facetPostProcessor;
+
+			if (facetPostProcessor != null) {
+				Map<String, Facet> facets = searchContext.getFacets();
+
+				for (Facet facet : facets.values()) {
+					facetPostProcessor.exclude(excludeDocs, facet);
+				}
+			}
+		}
+
+		hits.setDocs(docs.toArray(new Document[docs.size()]));
+		hits.setScores(ArrayUtil.toFloatArray(scores));
+		hits.setSearchTime(
+			(float)(System.currentTimeMillis() - hits.getStart()) /
+				Time.SECOND);
+		hits.setLength(hits.getLength() - excludeDocs.size());
+	}
+
+	@Override
+	protected Hits getHits(SearchContext searchContext) throws SearchException {
+		return _searchExecutor.search(searchContext);
+	}
+
+	@Override
+	protected boolean isGroupAdmin(SearchContext searchContext) {
+		long groupId = GetterUtil.getLong(
+			searchContext.getAttribute(Field.GROUP_ID));
+
+		if (groupId == 0) {
+			return false;
+		}
+
+		if (!_permissionChecker.isGroupAdmin(groupId)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean _isIncludeDocument(
+		Document document, long companyId, boolean companyAdmin, int status) {
+
+		long entryCompanyId = GetterUtil.getLong(
+			document.get(Field.COMPANY_ID));
+
+		if (entryCompanyId != companyId) {
+			return false;
+		}
+
+		if (companyAdmin) {
+			return true;
+		}
+
+		String entryClassName = document.get(Field.ENTRY_CLASS_NAME);
+
+		Indexer<?> indexer = IndexerRegistryUtil.getIndexer(entryClassName);
+
+		if (indexer == null) {
+			return true;
+		}
+
+		if (!indexer.isFilterSearch()) {
+			return true;
+		}
+
+		long entryClassPK = GetterUtil.getLong(
+			document.get(Field.ENTRY_CLASS_PK));
+
+		try {
+			if (indexer.hasPermission(
+					_permissionChecker, entryClassName, entryClassPK,
+					ActionKeys.VIEW)) {
+
+				List<RelatedEntryIndexer> relatedEntryIndexers =
+					RelatedEntryIndexerRegistryUtil.getRelatedEntryIndexers(
+						entryClassName);
+
+				if (ListUtil.isNotEmpty(relatedEntryIndexers)) {
+					for (RelatedEntryIndexer relatedEntryIndexer :
+							relatedEntryIndexers) {
+
+						relatedEntryIndexer.isVisibleRelatedEntry(
+							entryClassPK, status);
+					}
+				}
+
+				return true;
+			}
+		}
+		catch (Exception e) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(e, e);
+			}
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DefaultSearchResultPermissionFilter.class);
+
+	private static volatile FacetPostProcessor _facetPostProcessor =
+		ServiceProxyFactory.newServiceTrackedInstance(
+			FacetPostProcessor.class, DefaultSearchResultPermissionFilter.class,
+			"_facetPostProcessor", false, true);
+
+	private final PermissionChecker _permissionChecker;
+	private final SearchExecutor _searchExecutor;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.search.RelatedEntryIndexer;
 import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.search.SearchResultPermissionFilterFactory.SearchExecutor;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.FacetPostProcessor;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -54,12 +55,6 @@ public class DefaultSearchResultPermissionFilter
 
 		_searchExecutor = searchExecutor;
 		_permissionChecker = permissionChecker;
-	}
-
-	public interface SearchExecutor {
-
-		public Hits search(SearchContext searchContext) throws SearchException;
-
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
@@ -22,9 +22,9 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.RelatedEntryIndexer;
-import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistryUtil;
+import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.SearchResultPermissionFilterFactory.SearchExecutor;
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.ServiceProxyFactory;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -51,10 +50,16 @@ public class DefaultSearchResultPermissionFilter
 	extends BaseSearchResultPermissionFilter {
 
 	public DefaultSearchResultPermissionFilter(
-		SearchExecutor searchExecutor, PermissionChecker permissionChecker) {
+		FacetPostProcessor facetPostProcessor, IndexerRegistry indexerRegistry,
+		PermissionChecker permissionChecker,
+		RelatedEntryIndexerRegistry relatedEntryIndexerRegistry,
+		SearchExecutor searchExecutor) {
 
-		_searchExecutor = searchExecutor;
+		_facetPostProcessor = facetPostProcessor;
+		_indexerRegistry = indexerRegistry;
 		_permissionChecker = permissionChecker;
+		_relatedEntryIndexerRegistry = relatedEntryIndexerRegistry;
+		_searchExecutor = searchExecutor;
 	}
 
 	@Override
@@ -85,14 +90,10 @@ public class DefaultSearchResultPermissionFilter
 		}
 
 		if (!excludeDocs.isEmpty()) {
-			FacetPostProcessor facetPostProcessor = _facetPostProcessor;
+			Map<String, Facet> facets = searchContext.getFacets();
 
-			if (facetPostProcessor != null) {
-				Map<String, Facet> facets = searchContext.getFacets();
-
-				for (Facet facet : facets.values()) {
-					facetPostProcessor.exclude(excludeDocs, facet);
-				}
+			for (Facet facet : facets.values()) {
+				_facetPostProcessor.exclude(excludeDocs, facet);
 			}
 		}
 
@@ -141,7 +142,7 @@ public class DefaultSearchResultPermissionFilter
 
 		String entryClassName = document.get(Field.ENTRY_CLASS_NAME);
 
-		Indexer<?> indexer = IndexerRegistryUtil.getIndexer(entryClassName);
+		Indexer<?> indexer = _indexerRegistry.getIndexer(entryClassName);
 
 		if (indexer == null) {
 			return true;
@@ -160,7 +161,7 @@ public class DefaultSearchResultPermissionFilter
 					ActionKeys.VIEW)) {
 
 				List<RelatedEntryIndexer> relatedEntryIndexers =
-					RelatedEntryIndexerRegistryUtil.getRelatedEntryIndexers(
+					_relatedEntryIndexerRegistry.getRelatedEntryIndexers(
 						entryClassName);
 
 				if (ListUtil.isNotEmpty(relatedEntryIndexers)) {
@@ -187,12 +188,10 @@ public class DefaultSearchResultPermissionFilter
 	private static final Log _log = LogFactoryUtil.getLog(
 		DefaultSearchResultPermissionFilter.class);
 
-	private static volatile FacetPostProcessor _facetPostProcessor =
-		ServiceProxyFactory.newServiceTrackedInstance(
-			FacetPostProcessor.class, DefaultSearchResultPermissionFilter.class,
-			"_facetPostProcessor", false, true);
-
+	private final FacetPostProcessor _facetPostProcessor;
+	private final IndexerRegistry _indexerRegistry;
 	private final PermissionChecker _permissionChecker;
+	private final RelatedEntryIndexerRegistry _relatedEntryIndexerRegistry;
 	private final SearchExecutor _searchExecutor;
 
 }

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.permission;
+
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
+import com.liferay.portal.kernel.search.SearchResultPermissionFilter;
+import com.liferay.portal.kernel.search.SearchResultPermissionFilterFactory;
+import com.liferay.portal.kernel.search.facet.FacetPostProcessor;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eric Yan
+ */
+@Component(
+	immediate = true, service = SearchResultPermissionFilterFactory.class
+)
+public class SearchResultPermissionFilterFactoryImpl
+	implements SearchResultPermissionFilterFactory {
+
+	@Override
+	public SearchResultPermissionFilter create(
+		SearchExecutor searchExecutor, PermissionChecker permissionChecker) {
+
+		return new DefaultSearchResultPermissionFilter(
+			_facetPostProcessor, _indexerRegistry, permissionChecker,
+			_relatedEntryIndexerRegistry, searchExecutor);
+	}
+
+	@Reference
+	private FacetPostProcessor _facetPostProcessor;
+
+	@Reference
+	private IndexerRegistry _indexerRegistry;
+
+	@Reference
+	private RelatedEntryIndexerRegistry _relatedEntryIndexerRegistry;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -64,6 +64,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.ServiceProxyFactory;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
@@ -646,7 +647,7 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 				}
 
 				SearchResultPermissionFilter searchResultPermissionFilter =
-					new DefaultSearchResultPermissionFilter(
+					_searchResultPermissionFilterFactory.create(
 						this::doSearch, permissionChecker);
 
 				hits = searchResultPermissionFilter.search(searchContext);
@@ -1974,6 +1975,12 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 	private static final long _DEFAULT_FOLDER_ID = 0L;
 
 	private static final Log _log = LogFactoryUtil.getLog(BaseIndexer.class);
+
+	private static volatile SearchResultPermissionFilterFactory
+		_searchResultPermissionFilterFactory =
+			ServiceProxyFactory.newServiceTrackedInstance(
+				SearchResultPermissionFilterFactory.class, BaseIndexer.class,
+				"_searchResultPermissionFilterFactory", false);
 
 	private boolean _commitImmediately;
 	private String[] _defaultSelectedFieldNames;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseSearchResultPermissionFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseSearchResultPermissionFilter.java
@@ -30,7 +30,10 @@ import java.util.Set;
 
 /**
  * @author Tina Tian
+ * @deprecated As of 7.0.0, moved to {@link
+ *             com.liferay.portal.search.internal.permission.BaseSearchResultPermissionFilter}
  */
+@Deprecated
 public abstract class BaseSearchResultPermissionFilter
 	implements SearchResultPermissionFilter {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/DefaultSearchResultPermissionFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/DefaultSearchResultPermissionFilter.java
@@ -35,7 +35,10 @@ import java.util.Map;
 
 /**
  * @author Tina Tian
+ * @deprecated As of 7.0.0, moved to {@link
+ *             com.liferay.portal.search.internal.permission.DefaultSearchResultPermissionFilter}
  */
+@Deprecated
 @ProviderType
 public class DefaultSearchResultPermissionFilter
 	extends BaseSearchResultPermissionFilter {

--- a/portal-kernel/src/com/liferay/portal/kernel/search/SearchResultPermissionFilterFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/SearchResultPermissionFilterFactory.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.search;
+
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+
+/**
+ * @author Eric Yan
+ */
+public interface SearchResultPermissionFilterFactory {
+
+	public SearchResultPermissionFilter create(
+		SearchExecutor searchExecutor, PermissionChecker permissionChecker);
+
+	public interface SearchExecutor {
+
+		public Hits search(SearchContext searchContext) throws SearchException;
+
+	}
+
+}


### PR DESCRIPTION
Related Tickets: [LPS-77701: Move search result permission filter from core to portal-search](https://issues.liferay.com/browse/LPS-77701)
Previous PR: https://github.com/arboliveira/liferay-portal/pull/391

Hi @arboliveira,

This pr is for the task: **[TS] LPS-77701 BaseSearchResultPermissionFilter: Escape from Portal Core**

Please let me know if you have any questions.
Thanks!