### PR TITLE
[TS] LPS-78131 Solr: Asset Type won't work in asset publisher portlet

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImpl.java
@@ -367,16 +367,23 @@ public class FacetedSearcherImpl
 			SearchContext searchContext)
 		throws Exception {
 
+		BooleanFilter preFilterBooleanFilter = new BooleanFilter();
+
 		for (Entry<String, Indexer<?>> entry :
 				entryClassNameIndexerMap.entrySet()) {
 
 			String entryClassName = entry.getKey();
 			Indexer<?> indexer = entry.getValue();
 
-			queryBooleanFilter.add(
+			preFilterBooleanFilter.add(
 				_createPreFilterForEntryClassName(
 					entryClassName, indexer, searchContext),
 				BooleanClauseOccur.SHOULD);
+		}
+
+		if (preFilterBooleanFilter.hasClauses()) {
+			queryBooleanFilter.add(
+				preFilterBooleanFilter, BooleanClauseOccur.MUST);
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -1879,16 +1879,23 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 			SearchContext searchContext)
 		throws Exception {
 
+		BooleanFilter preFilterBooleanFilter = new BooleanFilter();
+
 		for (Entry<String, Indexer<?>> entry :
 				entryClassNameIndexerMap.entrySet()) {
 
 			String entryClassName = entry.getKey();
 			Indexer<?> indexer = entry.getValue();
 
-			queryBooleanFilter.add(
+			preFilterBooleanFilter.add(
 				_createPreFilterForEntryClassName(
 					entryClassName, indexer, searchContext),
 				BooleanClauseOccur.SHOULD);
+		}
+
+		if (preFilterBooleanFilter.hasClauses()) {
+			queryBooleanFilter.add(
+				preFilterBooleanFilter, BooleanClauseOccur.MUST);
 		}
 	}
 


### PR DESCRIPTION
Related Links:
[LPS-78131](https://issues.liferay.com/browse/LPS-78131)

Hi @arboliveira,

This issue only affects **Solr**. 
The commits in this pr **refine our logic** on how **pre-filters** are added, and **resolves** this issue in **Solr**.

**Additional Notes**
As discussed, the original query works properly in Elasticsearch, just not in Solr.
There appears to be a difference in how Elasticsearch and Solr are handling SHOULD clauses when used for filtering.

Task: **[TS] DIAGNOSE: LPS-78131 Solr: Asset Type won't work in asset publisher portlet**

Please let me know if you have any questions.
Thanks!