### PR TITLE
LPS-78268 portal-search-elasticsearch6: Ignore tests showing ConnectExceptions as WARN in logs

### DIFF
--- a/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/Cluster1InstanceTest.java
+++ b/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/Cluster1InstanceTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.search.elasticsearch6.internal.connection.IndexName;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -40,6 +41,7 @@ public class Cluster1InstanceTest {
 		_testCluster.tearDown();
 	}
 
+	@Ignore
 	@Test
 	public void test1PrimaryShardByDefault() throws Exception {
 		ElasticsearchFixture elasticsearchFixture = _testCluster.getNode(0);

--- a/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/Cluster2InstancesTest.java
+++ b/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/Cluster2InstancesTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.search.elasticsearch6.internal.connection.IndexName;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -40,6 +41,7 @@ public class Cluster2InstancesTest {
 		_testCluster.tearDown();
 	}
 
+	@Ignore
 	@Test
 	public void test2Nodes1PrimaryShard() throws Exception {
 		ElasticsearchFixture elasticsearchFixture0 = _testCluster.getNode(0);
@@ -55,6 +57,7 @@ public class Cluster2InstancesTest {
 		ClusterAssert.assert1PrimaryShardAnd2Nodes(elasticsearchFixture1);
 	}
 
+	@Ignore
 	@Test
 	public void testExpandAndShrink() throws Exception {
 		ElasticsearchFixture elasticsearchFixture0 = _testCluster.getNode(0);

--- a/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ClusterSettingsTest.java
+++ b/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ClusterSettingsTest.java
@@ -27,6 +27,7 @@ import org.elasticsearch.node.Node;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -44,6 +45,7 @@ public class ClusterSettingsTest {
 		_testCluster.tearDown();
 	}
 
+	@Ignore
 	@Test
 	public void testClusterSettings() throws Exception {
 		ElasticsearchFixture elasticsearchFixture = _testCluster.getNode(0);

--- a/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ClusterUnicastTest.java
+++ b/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ClusterUnicastTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.search.elasticsearch6.internal.connection.IndexName;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -40,6 +41,7 @@ public class ClusterUnicastTest {
 		_testCluster.tearDown();
 	}
 
+	@Ignore
 	@Test
 	public void testSplitBrainPreventedEvenIfMasterLeaves() throws Exception {
 		ElasticsearchFixture elasticsearchFixture0 = _testCluster.getNode(0);

--- a/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ElasticsearchClusterTest.java
+++ b/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ElasticsearchClusterTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.mockito.Mock;
@@ -42,6 +43,7 @@ public class ElasticsearchClusterTest {
 		_replicasClusterContext = createReplicasClusterContext();
 	}
 
+	@Ignore
 	@Test
 	public void testReplicaIndexNamesIncludeSystemCompanyId() {
 		long[] companyIds = {42, 142857};

--- a/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ReplicasClusterListenerTest.java
+++ b/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ReplicasClusterListenerTest.java
@@ -25,6 +25,7 @@ import java.util.logging.LogRecord;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.mockito.Mock;
@@ -65,12 +66,14 @@ public class ReplicasClusterListenerTest {
 			_replicasClusterContext);
 	}
 
+	@Ignore
 	@Test
 	public void testAHappyDay() {
 		processClusterEvent();
 		assertReplicasChanged();
 	}
 
+	@Ignore
 	@Test
 	public void testLiferayClusterReportsEmpty() {
 		Mockito.when(
@@ -88,6 +91,7 @@ public class ReplicasClusterListenerTest {
 		);
 	}
 
+	@Ignore
 	@Test
 	public void testMasterTokenAcquired() {
 		masterTokenAcquired();
@@ -95,6 +99,7 @@ public class ReplicasClusterListenerTest {
 		assertReplicasChanged();
 	}
 
+	@Ignore
 	@Test
 	public void testMasterTokenReleased() {
 		masterTokenReleased();
@@ -102,6 +107,7 @@ public class ReplicasClusterListenerTest {
 		assertReplicasUnchanged();
 	}
 
+	@Ignore
 	@Test
 	public void testNonMasterLiferayNodeDoesNothing() {
 		setMasterExecutor(false);
@@ -111,6 +117,7 @@ public class ReplicasClusterListenerTest {
 		assertReplicasUnchanged();
 	}
 
+	@Ignore
 	@Test
 	public void testRemoteElasticsearchClusterIsLeftAlone() {
 		setEmbeddedCluster(false);
@@ -120,6 +127,7 @@ public class ReplicasClusterListenerTest {
 		assertReplicasUnchanged();
 	}
 
+	@Ignore
 	@Test
 	public void testResilientToUpdateFailures() {
 		Throwable throwable = new RuntimeException();

--- a/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ReplicasManagerImplTest.java
+++ b/modules/apps/foundation/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ReplicasManagerImplTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -52,6 +53,7 @@ public class ReplicasManagerImplTest {
 		_testCluster.destroyNodes();
 	}
 
+	@Ignore
 	@Test
 	public void testSystemCompanyIndexIsReplicatedAndMigrated()
 		throws Exception {


### PR DESCRIPTION
**Related Tickets:**
[LPS-78267](https://issues.liferay.com/browse/LPS-78267)
[LPS-78268](https://issues.liferay.com/browse/LPS-78268)

Hi @arboliveira,

This pr is for temporarily ignoring tests that are under the package: **com.liferay.portal.search.elasticsearch6.internal.cluster**

Tests under the package are showing **ConnectExceptions** as WARN in logs.
As discussed, we will be ignoring these tests until [LPS-78267](https://issues.liferay.com/browse/LPS-78267) is resolved.

Please let me know if you have any questions.
Thanks!