### PR TITLE
LPS-78485 LiferayDocumentType defaults are excluded when using Additional Type Mappings in the Elasticsearch configuration

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/index/LiferayDocumentTypeFactory.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/index/LiferayDocumentTypeFactory.java
@@ -168,25 +168,30 @@ public class LiferayDocumentTypeFactory implements TypeMappingsHelper {
 
 		JSONObject sourceJSONObject = createJSONObject(source);
 
-		JSONArray sourceTemplatesJSONArray = sourceJSONObject.getJSONArray(
-			"dynamic_templates");
+		JSONObject sourceTypeJSONObject = sourceJSONObject;
 
-		if (sourceTemplatesJSONArray == null) {
-			return source;
+		if (sourceJSONObject.has(typeName)) {
+			sourceTypeJSONObject = sourceJSONObject.getJSONObject(typeName);
 		}
 
-		String mappings = getMappings(indexName, typeName);
+		JSONArray sourceTypeTemplatesJSONArray =
+			sourceTypeJSONObject.getJSONArray("dynamic_templates");
 
-		JSONObject mappingsJSONObject = createJSONObject(mappings);
+		if (sourceTypeTemplatesJSONArray != null) {
+			String mappings = getMappings(indexName, typeName);
 
-		JSONObject typeJSONObject = mappingsJSONObject.getJSONObject(typeName);
+			JSONObject mappingsJSONObject = createJSONObject(mappings);
 
-		JSONArray typeTemplatesJSONArray = typeJSONObject.getJSONArray(
-			"dynamic_templates");
+			JSONObject typeJSONObject = mappingsJSONObject.getJSONObject(
+				typeName);
 
-		sourceJSONObject.put(
-			"dynamic_templates",
-			merge(typeTemplatesJSONArray, sourceTemplatesJSONArray));
+			JSONArray typeTemplatesJSONArray = typeJSONObject.getJSONArray(
+				"dynamic_templates");
+
+			sourceTypeJSONObject.put(
+				"dynamic_templates",
+				merge(typeTemplatesJSONArray, sourceTypeTemplatesJSONArray));
+		}
 
 		return sourceJSONObject.toString();
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/index/CompanyIndexFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/index/CompanyIndexFactoryTest.java
@@ -96,6 +96,34 @@ public class CompanyIndexFactoryTest {
 		indexOneDocument(field);
 
 		assertAnalyzer(field, "kuromoji_liferay_custom");
+
+		field = RandomTestUtil.randomString() + "_en";
+
+		indexOneDocument(field);
+
+		assertAnalyzer(field, "english");
+	}
+
+	@Test
+	public void testAdditionalTypeMappingsWrapped() throws Exception {
+		_companyIndexFactory.setAdditionalIndexConfigurations(
+			loadAdditionalAnalyzers());
+		_companyIndexFactory.setAdditionalTypeMappings(
+			loadAdditionalTypeMappingsWrapped());
+
+		createIndices();
+
+		String field = RandomTestUtil.randomString() + "_ja";
+
+		indexOneDocument(field);
+
+		assertAnalyzer(field, "kuromoji_liferay_custom");
+
+		field = RandomTestUtil.randomString() + "_en";
+
+		indexOneDocument(field);
+
+		assertAnalyzer(field, "english");
 	}
 
 	@Test
@@ -353,6 +381,12 @@ public class CompanyIndexFactoryTest {
 	protected String loadAdditionalTypeMappings() throws Exception {
 		return ResourceUtil.getResourceAsString(
 			getClass(), "CompanyIndexFactoryTest-additionalTypeMappings.json");
+	}
+
+	protected String loadAdditionalTypeMappingsWrapped() throws Exception {
+		return ResourceUtil.getResourceAsString(
+			getClass(),
+			"CompanyIndexFactoryTest-additionalTypeMappings-wrapped.json");
 	}
 
 	protected String loadOverrideTypeMappings() throws Exception {

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/resources/com/liferay/portal/search/elasticsearch6/internal/index/CompanyIndexFactoryTest-additionalTypeMappings-wrapped.json
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/resources/com/liferay/portal/search/elasticsearch6/internal/index/CompanyIndexFactoryTest-additionalTypeMappings-wrapped.json
@@ -1,0 +1,19 @@
+{
+	"LiferayDocumentType": {
+		"dynamic_templates": [
+			{
+				"template_ja": {
+					"mapping": {
+						"analyzer": "kuromoji_liferay_custom",
+						"store": true,
+						"term_vector": "with_positions_offsets",
+						"type": "text"
+					},
+					"match": "\\w+_ja\\b|\\w+_ja_[A-Z]{2}\\b",
+					"match_mapping_type": "string",
+					"match_pattern": "regex"
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
Hi @arboliveira,

This pr is to fix the issue, where using the **Additional Type Mappings** section in the Elasticsearch configuration could override the default mappings.

**For example:**
```
{ 
    "LiferayDocumentType": {
        "dynamic_templates": []
    }
}
```

## Main Issue
Our current **mergeDynamicTemplates** logic does not account for mappings that are wrapped with the **Mapping Type** name, such as the example above.

Please let me know if you have any questions.
Thanks!

---

##  Additional Notes
The Elasticsearch REST API accepts mappings, regardless of whether the **Mapping Type** name is included or excluded.

**Without Mapping Type Name**
```
PUT liferay-20097/_mapping/LiferayDocumentType
{
  "dynamic_templates": []
}
```

**With Mapping Type Name**
```
PUT liferay-20097/_mapping/LiferayDocumentType
{ 
    "LiferayDocumentType": {
        "dynamic_templates": []
    }
}
```

Our solution preserves this behavior and mainly focuses on making sure the **dynamic_templates** field is merged properly.