### PR TITLE
LPS-78640 Cannot reconnect to remote Elasticsearch after improper settings are added to the Elasticsearch configuration, even after corrections

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/BaseElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/BaseElasticsearchConnection.java
@@ -52,6 +52,8 @@ public abstract class BaseElasticsearchConnection
 
 	@Override
 	public void connect() {
+		settingsBuilder = new SettingsBuilder(Settings.builder());
+
 		loadOptionalDefaultConfigurations();
 
 		loadAdditionalConfigurations();
@@ -162,7 +164,7 @@ public abstract class BaseElasticsearchConnection
 	}
 
 	protected volatile ElasticsearchConfiguration elasticsearchConfiguration;
-	protected final SettingsBuilder settingsBuilder = new SettingsBuilder(
+	protected SettingsBuilder settingsBuilder = new SettingsBuilder(
 		Settings.builder());
 
 	private Client _client;

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnection.java
@@ -176,6 +176,11 @@ public class RemoteElasticsearchConnection extends BaseElasticsearchConnection {
 
 		if (isConnected()) {
 			close();
+		}
+
+		if (!isConnected() && (elasticsearchConfiguration.operationMode() ==
+				com.liferay.portal.
+					search.elasticsearch6.configuration.OperationMode.REMOTE)) {
 
 			connect();
 		}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnectionTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnectionTest.java
@@ -14,7 +14,11 @@
 
 package com.liferay.portal.search.elasticsearch6.internal.connection;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.search.elasticsearch6.configuration.OperationMode;
 
 import java.net.InetSocketAddress;
 
@@ -49,6 +53,8 @@ public class RemoteElasticsearchConnectionTest {
 	public void testModifyConnected() {
 		HashMap<String, Object> properties = new HashMap<>();
 
+		properties.put("operationMode", OperationMode.REMOTE.name());
+
 		_remoteElasticsearchConnection.activate(properties);
 
 		Assert.assertFalse(_remoteElasticsearchConnection.isConnected());
@@ -69,14 +75,49 @@ public class RemoteElasticsearchConnectionTest {
 	}
 
 	@Test
+	public void testModifyConnectedWithInvalidPropertiesThenValidProperties() {
+		HashMap<String, Object> properties = new HashMap<>();
+
+		properties.put("operationMode", OperationMode.REMOTE.name());
+
+		_remoteElasticsearchConnection.activate(properties);
+
+		_remoteElasticsearchConnection.connect();
+
+		properties.put(
+			"additionalConfigurations",
+			StringBundler.concat(
+				StringPool.OPEN_CURLY_BRACE, RandomTestUtil.randomString(),
+				StringPool.CLOSE_CURLY_BRACE));
+
+		try {
+			_remoteElasticsearchConnection.modified(properties);
+
+			Assert.fail();
+		}
+		catch (NullPointerException npe) {
+		}
+
+		Assert.assertFalse(_remoteElasticsearchConnection.isConnected());
+
+		properties.replace("additionalConfigurations", StringPool.BLANK);
+
+		_remoteElasticsearchConnection.modified(properties);
+
+		Assert.assertTrue(_remoteElasticsearchConnection.isConnected());
+	}
+
+	@Test
 	public void testModifyUnconnected() {
 		Assert.assertFalse(_remoteElasticsearchConnection.isConnected());
 
 		HashMap<String, Object> properties = new HashMap<>();
 
+		properties.put("operationMode", OperationMode.REMOTE.name());
+
 		_remoteElasticsearchConnection.modified(properties);
 
-		Assert.assertFalse(_remoteElasticsearchConnection.isConnected());
+		Assert.assertTrue(_remoteElasticsearchConnection.isConnected());
 	}
 
 	protected void assertTransportAddress(String hostString, int port) {


### PR DESCRIPTION
[LPS-78640](https://issues.liferay.com/browse/LPS-78640)

Hi @arboliveira,

This pr fixes the issue where **remote ES cannot reconnect** after **improper settings** are introduced.
Below is a quick breakdown of the main commits:

1. [LPS-78640 portal-search-elasticsearch6-impl: connect if not started](https://github.com/arboliveira/liferay-portal/commit/5ba782378abc5b78a9f6fe2d27660e4f076b9ef2)
    * This commit allows us to recover from a previous failed connection.
2. [LPS-78640 portal-search-elasticsearch6-impl: recreate settings builder before creating a new connection, to prevent stale settings from being retained](https://github.com/arboliveira/liferay-portal/commit/a26de458ce706c3401029ac246b25dce2948e9a8)
    * This commit prevents stale settings from being retained
        * **Current behavior:** When additional configurations are added in the Elasticsearch configuration, settings builder retains these settings, even after we remove the added additional configurations and re-save.