### PR TITLE
LPS-81022 portal-search-web: Date Range Builder should expose normalizer; display builder should take range from facet config; normalize dates in facet builder only.

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/builder/DateRangeFactory.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/builder/DateRangeFactory.java
@@ -35,7 +35,7 @@ public class DateRangeFactory {
 	}
 
 	public String getRangeString(String label, Calendar calendar) {
-		return _normalizeDates(_rangeMap.get(label), calendar);
+		return replaceAliases(_rangeMap.get(label), calendar);
 	}
 
 	public String getRangeString(String from, String to) {
@@ -60,7 +60,7 @@ public class DateRangeFactory {
 		return map;
 	}
 
-	private String _normalizeDates(String rangeString, Calendar calendar) {
+	public String replaceAliases(String rangeString, Calendar calendar) {
 		Calendar now = (Calendar)calendar.clone();
 
 		Calendar pastHour = (Calendar)now.clone();

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/display/context/ModifiedFacetDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/display/context/ModifiedFacetDisplayBuilder.java
@@ -103,10 +103,6 @@ public class ModifiedFacetDisplayBuilder implements Serializable {
 			Objects.requireNonNull(parameterValues));
 	}
 
-	public void setRangesJSONArray(JSONArray rangesJSONArray) {
-		_rangesJSONArray = rangesJSONArray;
-	}
-
 	public void setTimeZone(TimeZone timeZone) {
 		_timeZone = timeZone;
 	}
@@ -187,7 +183,7 @@ public class ModifiedFacetDisplayBuilder implements Serializable {
 		modifiedFacetTermDisplayContext.setFrequency(
 			getFrequency(getTermCollector(range)));
 		modifiedFacetTermDisplayContext.setLabel(label);
-		modifiedFacetTermDisplayContext.setRange(label);
+		modifiedFacetTermDisplayContext.setRange(range);
 		modifiedFacetTermDisplayContext.setRangeURL(getLabeledRangeURL(label));
 		modifiedFacetTermDisplayContext.setSelected(
 			_selectedRanges.contains(label));
@@ -199,8 +195,10 @@ public class ModifiedFacetDisplayBuilder implements Serializable {
 		List<ModifiedFacetTermDisplayContext> modifiedFacetTermDisplayContexts =
 			new ArrayList<>();
 
-		for (int i = 0; i < _rangesJSONArray.length(); i++) {
-			JSONObject jsonObject = _rangesJSONArray.getJSONObject(i);
+		JSONArray rangesJSONArray = getRangesJSONArray();
+
+		for (int i = 0; i < rangesJSONArray.length(); i++) {
+			JSONObject jsonObject = rangesJSONArray.getJSONObject(i);
 
 			modifiedFacetTermDisplayContexts.add(
 				buildTermDisplayContext(
@@ -255,6 +253,14 @@ public class ModifiedFacetDisplayBuilder implements Serializable {
 		return _http.setParameter(rangeURL, "modified", label);
 	}
 
+	protected JSONArray getRangesJSONArray() {
+		FacetConfiguration facetConfiguration = _facet.getFacetConfiguration();
+
+		JSONObject dataJSONObject = facetConfiguration.getData();
+
+		return dataJSONObject.getJSONArray("ranges");
+	}
+
 	protected TermCollector getTermCollector(String range) {
 		FacetCollector facetCollector = _facet.getFacetCollector();
 
@@ -302,7 +308,6 @@ public class ModifiedFacetDisplayBuilder implements Serializable {
 	private final Http _http;
 	private Locale _locale;
 	private String _parameterName;
-	private JSONArray _rangesJSONArray;
 	private List<String> _selectedRanges = Collections.emptyList();
 	private TimeZone _timeZone;
 	private String _to;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/ModifiedFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/ModifiedFacetPortlet.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.search.web.internal.modified.facet.portlet;
 
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -29,8 +27,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.facet.modified.ModifiedFacetFactory;
 import com.liferay.portal.search.web.internal.display.context.PortletRequestThemeDisplaySupplier;
 import com.liferay.portal.search.web.internal.display.context.ThemeDisplaySupplier;
-import com.liferay.portal.search.web.internal.modified.facet.builder.ModifiedFacetConfiguration;
-import com.liferay.portal.search.web.internal.modified.facet.builder.ModifiedFacetConfigurationImpl;
 import com.liferay.portal.search.web.internal.modified.facet.constants.ModifiedFacetPortletKeys;
 import com.liferay.portal.search.web.internal.modified.facet.display.context.ModifiedFacetDisplayBuilder;
 import com.liferay.portal.search.web.internal.modified.facet.display.context.ModifiedFacetDisplayContext;
@@ -119,13 +115,6 @@ public class ModifiedFacetPortlet extends MVCPortlet {
 
 		modifiedFacetDisplayBuilder.setFacet(facet);
 
-		ModifiedFacetConfigurationImpl modifiedFacetConfiguration =
-			new ModifiedFacetConfigurationImpl(facet.getFacetConfiguration());
-
-		modifiedFacetDisplayBuilder.setRangesJSONArray(
-			getRangesJSONArray(
-				modifiedFacetConfiguration, modifiedFacetPortletPreferences));
-
 		ThemeDisplay themeDisplay = getThemeDisplay(renderRequest);
 
 		modifiedFacetDisplayBuilder.setLocale(themeDisplay.getLocale());
@@ -190,29 +179,6 @@ public class ModifiedFacetPortlet extends MVCPortlet {
 
 		return new ModifiedFacetPortletPreferencesImpl(
 			Optional.ofNullable(renderRequest.getPreferences()));
-	}
-
-	protected JSONArray getRangesJSONArray(
-		ModifiedFacetConfiguration modifiedFacetConfiguration,
-		ModifiedFacetPortletPreferences modifiedFacetPortletPreferences) {
-
-		JSONArray rangesJSONArray =
-			modifiedFacetConfiguration.getRangesJSONArray();
-
-		JSONArray rangesFromPreferencesJSONArray =
-			modifiedFacetPortletPreferences.getRangesJSONArray();
-
-		for (int i = 0; i < rangesJSONArray.length(); i++) {
-			JSONObject rangeJSONObject = rangesJSONArray.getJSONObject(i);
-			JSONObject rangeFromPreferenceJSONObject =
-				rangesFromPreferencesJSONArray.getJSONObject(i);
-
-			rangeJSONObject.remove("label");
-			rangeJSONObject.put(
-				"label", rangeFromPreferenceJSONObject.get("label"));
-		}
-
-		return rangesJSONArray;
 	}
 
 	protected ThemeDisplay getThemeDisplay(RenderRequest renderRequest) {

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/config.js
@@ -2,17 +2,6 @@
 	AUI().applyConfig(
 		{
 			groups: {
-				modified_facet: {
-					base: MODULE_PATH + '/js/',
-					combine: Liferay.AUI.getCombine(),
-					modules: {
-						'liferay-search-modified-facet': {
-							path: 'modified_facet.js',
-							requires: ['liferay-search-facet-util']
-						}
-					},
-					root: MODULE_PATH + '/js/'
-				},
 				search: {
 					base: MODULE_PATH + '/js/',
 					combine: Liferay.AUI.getCombine(),
@@ -25,6 +14,14 @@
 						'liferay-search-facet-util': {
 							path: 'facet_util.js',
 							requires: []
+						},
+						'liferay-search-modified-facet': {
+							path: 'modified_facet.js',
+							requires: ['liferay-search-facet-util']
+						},
+						'liferay-search-modified-facet-configuration': {
+							path: 'modified_facet_configuration.js',
+							requires: ['aui-node']
 						}
 					},
 					root: MODULE_PATH + '/js/'

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/modified_facet_configuration.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/modified_facet_configuration.js
@@ -1,0 +1,56 @@
+AUI.add(
+	'liferay-search-modified-facet-configuration',
+	function(A) {
+		var ModifiedFacetConfiguration = function(form) {
+			var instance = this;
+
+			instance.form = form;
+
+			instance.form.on('submit', A.bind(instance._onSubmit, instance));
+		};
+
+		A.mix(
+			ModifiedFacetConfiguration.prototype,
+			{
+				_onSubmit: function(event) {
+					var instance = this;
+
+					event.preventDefault();
+
+					var ranges = [];
+
+					var rangeFormRows = A.all('.range-form-row').filter(
+						function(item) {
+							return !item.get('hidden');
+						}
+					);
+
+					rangeFormRows.each(
+						function(item) {
+							var label = item.one('.label-input').val();
+
+							var range = item.one('.range-input').val();
+
+							ranges.push(
+								{
+									label: label,
+									range: range
+								}
+							);
+						}
+					);
+
+					instance.form.one('.ranges-input').val(JSON.stringify(ranges));
+
+					submitForm(instance.form);
+				}
+			}
+		);
+
+		Liferay.namespace('Search').ModifiedFacetConfiguration = ModifiedFacetConfiguration;
+	},
+	'',
+	{
+		requires: ['aui-node']
+	}
+);

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/configuration.jsp
@@ -61,9 +61,11 @@ JSONArray rangesJSONArray = modifiedFacetPortletPreferences.getRangesJSONArray()
 					JSONObject jsonObject = rangesJSONArray.getJSONObject(i);
 				%>
 
-					<div class="lfr-form-row lfr-form-row-inline">
+					<div class="lfr-form-row lfr-form-row-inline range-form-row">
 						<div class="row-fields">
-							<aui:input label="label" name='<%= "label_" + i %>' value='<%= jsonObject.getString("label") %>' />
+							<aui:input cssClass="label-input" label="label" name='<%= "label_" + i %>' value='<%= jsonObject.getString("label") %>' />
+
+							<aui:input cssClass="range-input" label="range" name='<%= "range_" + i %>' value='<%= jsonObject.getString("range") %>' />
 						</div>
 					</div>
 
@@ -71,7 +73,7 @@ JSONArray rangesJSONArray = modifiedFacetPortletPreferences.getRangesJSONArray()
 				}
 				%>
 
-				<aui:input name="<%= PortletPreferencesJspUtil.getInputName(ModifiedFacetPortletPreferences.PREFERENCE_KEY_RANGES) %>" type="hidden" value="<%= modifiedFacetPortletPreferences.getRangesString() %>" />
+				<aui:input cssClass="ranges-input" name="<%= PortletPreferencesJspUtil.getInputName(ModifiedFacetPortletPreferences.PREFERENCE_KEY_RANGES) %>" type="hidden" value="<%= modifiedFacetPortletPreferences.getRangesString() %>" />
 
 				<aui:input name='<%= "rangesIndexes" %>' type="hidden" value="<%= StringUtil.merge(rangesIndexes) %>" />
 			</aui:fieldset>
@@ -95,26 +97,6 @@ JSONArray rangesJSONArray = modifiedFacetPortletPreferences.getRangesJSONArray()
 	).render();
 </aui:script>
 
-<aui:script>
-	var form = AUI.$(document.<portlet:namespace />fm);
-
-	$('#<portlet:namespace />fm').on(
-		'submit',
-		function(event) {
-			event.preventDefault();
-
-			var ranges = [];
-
-			for (var i = 0 ; i < <%= rangesJSONArray.length() %> ; i ++) {
-				var label = $('[name="<portlet:namespace />label_' + i +'"]').val();
-
-				ranges.push({
-					label : label
-				});
-			}
-			form.fm('<%= PortletPreferencesJspUtil.getInputName(ModifiedFacetPortletPreferences.PREFERENCE_KEY_RANGES) %>').val(JSON.stringify(ranges));
-
-			submitForm(form);
-		}
-	);
+<aui:script use="liferay-search-modified-facet-configuration">
+	new Liferay.Search.ModifiedFacetConfiguration(A.one(document.<portlet:namespace />fm));
 </aui:script>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/configuration.jsp
@@ -25,6 +25,7 @@ page import="com.liferay.portal.search.web.internal.util.PortletPreferencesJspUt
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %>
 
 <portlet:defineObjects />

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/DateRangeFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/DateRangeFactoryTest.java
@@ -47,6 +47,60 @@ public class DateRangeFactoryTest {
 			_dateRangeFactory.getRangeString("past-24-hours", calendar));
 	}
 
+	@Test
+	public void testReplaceAliasPast24Hours() {
+		Calendar calendar = new GregorianCalendar(
+			2018, Calendar.MAY, 15, 23, 59, 59);
+
+		Assert.assertEquals(
+			"[20180514235959 TO 20180515225959]",
+			_dateRangeFactory.replaceAliases(
+				"[past-24-hours TO past-hour]", calendar));
+	}
+
+	@Test
+	public void testReplaceAliasPastHour() {
+		Calendar calendar = new GregorianCalendar(
+			2018, Calendar.MAY, 15, 23, 59, 59);
+
+		Assert.assertEquals(
+			"[20180515225959 TO 20180515235959]",
+			_dateRangeFactory.replaceAliases("[past-hour TO *]", calendar));
+	}
+
+	@Test
+	public void testReplaceAliasPastMonth() {
+		Calendar calendar = new GregorianCalendar(
+			2018, Calendar.MAY, 15, 23, 59, 59);
+
+		Assert.assertEquals(
+			"[20180415235959 TO 20180508235959]",
+			_dateRangeFactory.replaceAliases(
+				"[past-month TO past-week]", calendar));
+	}
+
+	@Test
+	public void testReplaceAliasPastWeek() {
+		Calendar calendar = new GregorianCalendar(
+			2018, Calendar.MAY, 15, 23, 59, 59);
+
+		Assert.assertEquals(
+			"[20180508235959 TO 20180514235959]",
+			_dateRangeFactory.replaceAliases(
+				"[past-week TO past-24-hours]", calendar));
+	}
+
+	@Test
+	public void testReplaceAliasPastYear() {
+		Calendar calendar = new GregorianCalendar(
+			2018, Calendar.MAY, 15, 23, 59, 59);
+
+		Assert.assertEquals(
+			"[20170515235959 TO 20180415235959]",
+			_dateRangeFactory.replaceAliases(
+				"[past-year TO past-month]", calendar));
+	}
+
 	private final DateRangeFactory _dateRangeFactory = new DateRangeFactory(
 		new DateFormatFactoryImpl());
 

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilderTest.java
@@ -15,9 +15,12 @@
 package com.liferay.portal.search.web.internal.modified.facet.builder;
 
 import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
 import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.DateFormatFactory;
@@ -46,6 +49,7 @@ public class ModifiedFacetBuilderTest {
 	public void setUp() {
 		calendarFactory = createCalendarFactory();
 		dateFormatFactory = new DateFormatFactoryImpl();
+		jsonFactory = new JSONFactoryImpl();
 
 		setUpJSONFactoryUtil();
 	}
@@ -79,11 +83,78 @@ public class ModifiedFacetBuilderTest {
 			"20180228151923", "20180301151923", modifiedFacetBuilder.build());
 	}
 
+	@Test
+	public void testUseRangeSelectionFromSetRanges() {
+		ModifiedFacetBuilder modifiedFacetBuilder =
+			createModifiedFacetBuilder();
+
+		JSONArray rangesJSONArray = createRangesJSONArray(
+			"eighties", "[19800101000000 TO 19891231235959]");
+
+		modifiedFacetBuilder.setRangesJSONArray(rangesJSONArray);
+
+		modifiedFacetBuilder.setSelectedRanges("eighties");
+
+		assertRange(
+			"19800101000000", "19891231235959", modifiedFacetBuilder.build());
+	}
+
+	@Test
+	public void testUseSetRanges() {
+		ModifiedFacetBuilder modifiedFacetBuilder =
+			createModifiedFacetBuilder();
+
+		JSONArray rangesJSONArray = createRangesJSONArray();
+
+		modifiedFacetBuilder.setRangesJSONArray(rangesJSONArray);
+
+		assertRangesJSONArray(rangesJSONArray, modifiedFacetBuilder.build());
+	}
+
+	protected void addRangeJSONObject(
+		JSONArray jsonArray, String label, String range) {
+
+		JSONObject jsonObject = jsonFactory.createJSONObject();
+
+		jsonObject.put("label", label);
+		jsonObject.put("range", range);
+
+		jsonArray.put(jsonObject);
+	}
+
 	protected void assertRange(String from, String to, Facet facet) {
 		List<String> calendars = getRangeBounds(facet);
 
 		Assert.assertEquals(from, calendars.get(0));
 		Assert.assertEquals(to, calendars.get(1));
+	}
+
+	protected void assertRangeJSONObjectEquals(
+		JSONObject jsonObject1, JSONObject jsonObject2) {
+
+		Assert.assertEquals(
+			jsonObject1.getString("label"), jsonObject2.getString("label"));
+		Assert.assertEquals(
+			jsonObject1.getString("range"), jsonObject2.getString("range"));
+	}
+
+	protected void assertRangesJSONArray(
+		JSONArray rangesJSONArray, Facet facet) {
+
+		FacetConfiguration facetConfiguration = facet.getFacetConfiguration();
+
+		JSONObject data = facetConfiguration.getData();
+
+		JSONArray facetRangesJSONArray = data.getJSONArray("ranges");
+
+		Assert.assertEquals(
+			rangesJSONArray.length(), facetRangesJSONArray.length());
+
+		for (int i = 0; i < rangesJSONArray.length(); i++) {
+			assertRangeJSONObjectEquals(
+				rangesJSONArray.getJSONObject(i),
+				facetRangesJSONArray.getJSONObject(i));
+		}
 	}
 
 	protected CalendarFactory createCalendarFactory() {
@@ -129,6 +200,26 @@ public class ModifiedFacetBuilderTest {
 		return modifiedFacetFactory;
 	}
 
+	protected JSONArray createRangesJSONArray() {
+		return createRangesJSONArray(
+			"past-hour", "[20180215120000 TO 20180215140000]", "past-24-hours",
+			"[20180214130000 TO 20180215140000]", "past-week",
+			"[20180208130000 TO 20180215140000]", "past-month",
+			"[20180115130000 TO 20180215140000]", "past-year",
+			"[20170215130000 TO 20180215140000]");
+	}
+
+	protected JSONArray createRangesJSONArray(String... labelsAndRanges) {
+		JSONArray jsonArray = jsonFactory.createJSONArray();
+
+		for (int i = 0; i < labelsAndRanges.length; i += 2) {
+			addRangeJSONObject(
+				jsonArray, labelsAndRanges[i], labelsAndRanges[i + 1]);
+		}
+
+		return jsonArray;
+	}
+
 	protected List<String> getRangeBounds(Facet facet) {
 		String range = facet.getSelections()[0];
 
@@ -145,5 +236,6 @@ public class ModifiedFacetBuilderTest {
 
 	protected CalendarFactory calendarFactory;
 	protected DateFormatFactory dateFormatFactory;
+	protected JSONFactoryImpl jsonFactory;
 
 }


### PR DESCRIPTION
Issue: [LPS-81022](https://issues.liferay.com/browse/LPS-81022).
Test results: https://github.com/brandizzi/liferay-portal/pull/556#issuecomment-395205948

There are some failures but seem not related: most tests pass, and no modified facet appears in them.