### PR TITLE
J cords lps 83181 83186 3

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelSummaryContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelSummaryContributor.java
@@ -18,8 +18,10 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
 import com.liferay.portal.search.summary.SummaryHelper;
@@ -80,7 +82,7 @@ public class CalendarBookingModelSummaryContributor
 				defaultLocale, prefix + Field.DESCRIPTION, Field.DESCRIPTION);
 		}
 
-		description = HtmlUtil.extractText(description);
+		description = _stripAndHighlight(description);
 
 		Summary summary = new Summary(snippetLocale, title, description);
 
@@ -88,6 +90,24 @@ public class CalendarBookingModelSummaryContributor
 
 		return summary;
 	}
+
+	private String _stripAndHighlight(String text) {
+		text = StringUtil.replace(
+			text, _HIGHLIGHT_TAGS, _ESCAPE_SAFE_HIGHLIGHTS);
+
+		text = HtmlUtil.stripHtml(text);
+
+		text = StringUtil.replace(
+			text, _ESCAPE_SAFE_HIGHLIGHTS, _HIGHLIGHT_TAGS);
+
+		return text;
+	}
+
+	private static final String[] _ESCAPE_SAFE_HIGHLIGHTS =
+		{"[@HIGHLIGHT1@]", "[@HIGHLIGHT2@]"};
+
+	private static final String[] _HIGHLIGHT_TAGS =
+		{HighlightUtil.HIGHLIGHT_TAG_OPEN, HighlightUtil.HIGHLIGHT_TAG_CLOSE};
 
 	@Reference
 	protected SummaryHelper summaryHelper;

--- a/modules/apps/deprecated/journal-content-search-web/src/main/java/com/liferay/journal/content/search/web/internal/display/context/JournalContentSearchDisplayContext.java
+++ b/modules/apps/deprecated/journal-content-search-web/src/main/java/com/liferay/journal/content/search/web/internal/display/context/JournalContentSearchDisplayContext.java
@@ -162,7 +162,7 @@ public class JournalContentSearchDisplayContext {
 
 		SummaryBuilder summaryBuilder = _summaryBuilderFactory.newInstance();
 
-		summaryBuilder.setContent(summary.getContent());
+		summaryBuilder.setContent(summary.getFullContent());
 		summaryBuilder.setHighlight(
 			_journalContentSearchPortletInstanceConfiguration.
 				enableHighlighting());

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
@@ -583,7 +583,7 @@ public class SearchResultSummaryDisplayBuilder {
 					_document, snippet, _renderRequest, _renderResponse);
 
 			if (summary != null) {
-				summaryBuilder.setContent(summary.getContent());
+				summaryBuilder.setContent(summary.getFullContent());
 				summaryBuilder.setLocale(summary.getLocale());
 				summaryBuilder.setMaxContentLength(
 					summary.getMaxContentLength());

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
@@ -81,6 +81,12 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 	}
 
 	protected String buildContentHighlighted() {
+		int virtualMaxContentLength = _maxContentLength;
+
+		if (_maxContentLength < _content.length()) {
+			virtualMaxContentLength = _recalculateHighlightMaxLength();
+		}
+
 		_shortenHighlightedContent();
 
 		if (_content.lastIndexOf(HighlightUtil.HIGHLIGHT_TAG_CLOSE) <
@@ -101,6 +107,7 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 				_content.concat(HighlightUtil.HIGHLIGHT_TAG_CLOSE);
 			}
 		}
+
 		return _escapeAndHighlight(_content);
 	}
 
@@ -146,6 +153,56 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 			text, _ESCAPE_SAFE_HIGHLIGHTS, HighlightUtil.HIGHLIGHTS);
 
 		return text;
+	}
+
+	private int _recalculateHighlightMaxLength() {
+		String extractedContent = _html.extractText(_content);
+
+		if (extractedContent.length() <= _maxContentLength) {
+			_maxContentLength = _content.length();
+
+			return _maxContentLength;
+		}
+
+		int currentLength = 0;
+		int highlightLength = 0;
+		int indexClose = _content.indexOf(
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE, currentLength);
+		int indexOpen = _content.indexOf(
+			HighlightUtil.HIGHLIGHT_TAG_OPEN, currentLength);
+
+		while ((indexClose > 0) || (indexOpen > 0)) {
+			if ((indexOpen > -1) &&
+				((indexOpen < indexClose) || (indexClose < 0))) {
+
+				currentLength = indexOpen - highlightLength;
+
+				if (currentLength >= _maxContentLength) {
+					break;
+				}
+
+				highlightLength += HighlightUtil.HIGHLIGHT_TAG_OPEN.length();
+				indexOpen = _content.indexOf(
+					HighlightUtil.HIGHLIGHT_TAG_OPEN,
+					currentLength + highlightLength);
+			}
+			else if ((indexClose > -1) &&
+					 ((indexClose < indexOpen) || (indexOpen < 0))) {
+
+				currentLength = indexClose - highlightLength;
+
+				if (currentLength >= _maxContentLength) {
+					break;
+				}
+
+				highlightLength += HighlightUtil.HIGHLIGHT_TAG_CLOSE.length();
+				indexClose = _content.indexOf(
+					HighlightUtil.HIGHLIGHT_TAG_CLOSE,
+					currentLength + highlightLength);
+			}
+		}
+
+		return _maxContentLength + highlightLength;
 	}
 
 	private void _shortenHighlightedContent() {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
@@ -87,7 +87,7 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 			virtualMaxContentLength = _recalculateHighlightMaxLength();
 		}
 
-		_shortenHighlightedContent();
+		_shortenHighlightedContent(virtualMaxContentLength);
 
 		if (_content.lastIndexOf(HighlightUtil.HIGHLIGHT_TAG_CLOSE) <
 				_content.lastIndexOf(HighlightUtil.HIGHLIGHT_TAG_OPEN)) {
@@ -205,17 +205,32 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 		return _maxContentLength + highlightLength;
 	}
 
-	private void _shortenHighlightedContent() {
+	private void _shortenHighlightedContent(int virtualMaxContentLength) {
 		if (_content.length() > _maxContentLength) {
+			if (_maxContentLength < 4) {
+				if (_maxContentLength < 0) {
+					_maxContentLength = 0;
+				}
+
+				if (_maxContentLength == 3) {
+					_content = "...";
+				}
+				else {
+					_content = _content.substring(0, _maxContentLength);
+				}
+
+				return;
+			}
+
 			String shortenedContent = StringUtil.shorten(
-				_content, _maxContentLength - 3, "");
+				_content, virtualMaxContentLength - 3, "");
 
 			int indexLastTagOpen = shortenedContent.lastIndexOf("<");
 
 			if ((indexLastTagOpen > -1) &&
 				(indexLastTagOpen >
-					(_maxContentLength - HighlightUtil.
-						HIGHLIGHT_TAG_CLOSE.length()))) {
+					(virtualMaxContentLength - HighlightUtil.
+						HIGHLIGHT_TAG_CLOSE.length() - 3))) {
 
 				int endIndex =
 					indexLastTagOpen +
@@ -226,16 +241,23 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 				}
 
 				String ending = _content.substring(indexLastTagOpen, endIndex);
+				int cutLength = 3;
 
 				if (ending.contains(HighlightUtil.HIGHLIGHT_TAG_CLOSE)) {
-					shortenedContent = shortenedContent.substring(
-						0, indexLastTagOpen);
-					shortenedContent = shortenedContent.concat(
-						HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+					cutLength -= virtualMaxContentLength - indexLastTagOpen -
+						HighlightUtil.HIGHLIGHT_TAG_CLOSE.length();
+					shortenedContent = _content.substring(
+						0, indexLastTagOpen - cutLength);
+
+					shortenedContent += HighlightUtil.HIGHLIGHT_TAG_CLOSE;
 				}
 				else if (ending.contains(HighlightUtil.HIGHLIGHT_TAG_OPEN)) {
-					shortenedContent = shortenedContent.substring(
-						0, indexLastTagOpen);
+					cutLength -= virtualMaxContentLength - indexLastTagOpen -
+						HighlightUtil.HIGHLIGHT_TAG_OPEN.length();
+					shortenedContent = _content.substring(
+						0, indexLastTagOpen - cutLength);
+
+					shortenedContent += HighlightUtil.HIGHLIGHT_TAG_OPEN;
 				}
 			}
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
@@ -232,16 +232,12 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 					(virtualMaxContentLength - HighlightUtil.
 						HIGHLIGHT_TAG_CLOSE.length() - 3))) {
 
+				int cutLength = 3;
 				int endIndex =
 					indexLastTagOpen +
 						HighlightUtil.HIGHLIGHT_TAG_CLOSE.length();
 
-				if (endIndex > _content.length()) {
-					endIndex = _content.length();
-				}
-
 				String ending = _content.substring(indexLastTagOpen, endIndex);
-				int cutLength = 3;
 
 				if (ending.contains(HighlightUtil.HIGHLIGHT_TAG_CLOSE)) {
 					cutLength -= virtualMaxContentLength - indexLastTagOpen -

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
@@ -81,6 +81,8 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 	}
 
 	protected String buildContentHighlighted() {
+		_shortenHighlightedContent();
+
 		return _escapeAndHighlight(_content);
 	}
 
@@ -126,6 +128,46 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 			text, _ESCAPE_SAFE_HIGHLIGHTS, HighlightUtil.HIGHLIGHTS);
 
 		return text;
+	}
+
+	private void _shortenHighlightedContent() {
+		if (_content.length() > _maxContentLength) {
+			String shortenedContent = StringUtil.shorten(
+				_content, _maxContentLength - 3, "");
+
+			int indexLastTagOpen = shortenedContent.lastIndexOf("<");
+
+			if ((indexLastTagOpen > -1) &&
+				(indexLastTagOpen >
+					(_maxContentLength - HighlightUtil.
+						HIGHLIGHT_TAG_CLOSE.length()))) {
+
+				int endIndex =
+					indexLastTagOpen +
+						HighlightUtil.HIGHLIGHT_TAG_CLOSE.length();
+
+				if (endIndex > _content.length()) {
+					endIndex = _content.length();
+				}
+
+				String ending = _content.substring(indexLastTagOpen, endIndex);
+
+				if (ending.contains(HighlightUtil.HIGHLIGHT_TAG_CLOSE)) {
+					shortenedContent = shortenedContent.substring(
+						0, indexLastTagOpen);
+					shortenedContent = shortenedContent.concat(
+						HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+				}
+				else if (ending.contains(HighlightUtil.HIGHLIGHT_TAG_OPEN)) {
+					shortenedContent = shortenedContent.substring(
+						0, indexLastTagOpen);
+				}
+			}
+
+			shortenedContent = shortenedContent.concat("...");
+
+			_content = shortenedContent;
+		}
 	}
 
 	private static final String[] _ESCAPE_SAFE_HIGHLIGHTS =

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/summary/SummaryBuilderImpl.java
@@ -83,6 +83,24 @@ public class SummaryBuilderImpl implements SummaryBuilder {
 	protected String buildContentHighlighted() {
 		_shortenHighlightedContent();
 
+		if (_content.lastIndexOf(HighlightUtil.HIGHLIGHT_TAG_CLOSE) <
+				_content.lastIndexOf(HighlightUtil.HIGHLIGHT_TAG_OPEN)) {
+
+			if (_content.endsWith("...")) {
+				StringBuilder sb = new StringBuilder(
+					_maxContentLength +
+						HighlightUtil.HIGHLIGHT_TAG_CLOSE.length());
+
+				sb.append(_content.substring(0, _content.lastIndexOf("...")));
+				sb.append(HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+				sb.append("...");
+
+				_content = sb.toString();
+			}
+			else {
+				_content.concat(HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+			}
+		}
 		return _escapeAndHighlight(_content);
 	}
 

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/summary/SummaryBuilderImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/summary/SummaryBuilderImplTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.internal.summary;
 import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.summary.Summary;
 import com.liferay.portal.search.summary.SummaryBuilder;
 
@@ -48,17 +49,126 @@ public class SummaryBuilderImplTest {
 				"GGG<strong>HHH</strong>III"));
 
 		_summaryBuilder.setHighlight(true);
+		_summaryBuilder.setMaxContentLength(200);
 
 		Summary summary = _summaryBuilder.build();
 
-		Assert.assertEquals(
-			StringBundler.concat(
-				"AAA&lt;strong&gt;BBB&lt;/strong&gt;CCC",
-				HighlightUtil.HIGHLIGHTS[0],
-				"DDD&lt;strong&gt;EEE&lt;/strong&gt;FFF",
-				HighlightUtil.HIGHLIGHTS[1],
-				"GGG&lt;strong&gt;HHH&lt;/strong&gt;III"),
+		assertHighlightEquals(
+			"AAA&lt;strong&gt;BBB&lt;/strong&gt;CCC[[DDD&lt;strong&gt;EEE" +
+				"&lt;/strong&gt;FFF]]GGG&lt;strong&gt;HHH&lt;/strong&gt;III",
 			summary.getContent());
+	}
+
+	@Test
+	public void testContentHighlightCuttingNoSpaces() {
+		StringBundler sb = new StringBundler(4);
+		String content = "";
+		String actualContent = "";
+		String highlightedContent = RandomTestUtil.randomString(9);
+		String normalContent = RandomTestUtil.randomString(10);
+
+		sb.append(HighlightUtil.HIGHLIGHT_TAG_OPEN);
+		sb.append(highlightedContent);
+		sb.append(HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+		sb.append(normalContent);
+
+		_summaryBuilder.setHighlight(true);
+
+		content = sb.toString();
+
+		for (int i = 0; i < 21; i++) {
+			_summaryBuilder.setContent(content);
+			_summaryBuilder.setMaxContentLength(i);
+
+			Summary summary = _summaryBuilder.build();
+
+			actualContent = summary.getContent();
+
+			if (i == 0) {
+				assertHighlightEquals("", actualContent);
+			}
+			else if (i == 1) {
+				assertHighlightEquals("&lt;", actualContent);
+			}
+			else if (i == 2) {
+				assertHighlightEquals("&lt;l", actualContent);
+			}
+			else if (i == 3) {
+				assertHighlightEquals("...", actualContent);
+			}
+			else if (i == 20) {
+				assertHighlightEquals(
+					"[[" + highlightedContent + "]]" + normalContent,
+					actualContent);
+			}
+			else {
+				_assertNoSpaceResult(
+					highlightedContent, normalContent, i, actualContent);
+			}
+		}
+	}
+
+	@Test
+	public void testContentHighlightCuttingSpaces() {
+		StringBundler sb = new StringBundler();
+		String content;
+		String actualContent;
+		String highlightedContent = RandomTestUtil.randomString(4);
+		String normalContent = RandomTestUtil.randomString(4);
+
+		sb.append(HighlightUtil.HIGHLIGHT_TAG_OPEN);
+		sb.append(highlightedContent);
+		sb.append(" ");
+		sb.append(highlightedContent);
+		sb.append(HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+		sb.append(" ");
+		sb.append(normalContent);
+		sb.append(" ");
+		sb.append(normalContent);
+
+		_summaryBuilder.setHighlight(true);
+
+		content = sb.toString();
+
+		for (int i = 0; i < 20; i++) {
+			_summaryBuilder.setContent(content);
+			_summaryBuilder.setMaxContentLength(i);
+
+			Summary summary = _summaryBuilder.build();
+
+			actualContent = summary.getContent();
+
+			if (i == 0) {
+				assertHighlightEquals("", actualContent);
+			}
+			else if (i == 1) {
+				assertHighlightEquals("&lt;", actualContent);
+			}
+			else if (i == 2) {
+				assertHighlightEquals("&lt;l", actualContent);
+			}
+			else if (i == 3) {
+				assertHighlightEquals("...", actualContent);
+			}
+			else if (i == 19) {
+				sb = new StringBundler(23);
+
+				sb.append("[[");
+				sb.append(highlightedContent);
+				sb.append(" ");
+				sb.append(highlightedContent);
+				sb.append("]] ");
+				sb.append(normalContent);
+				sb.append(" ");
+				sb.append(normalContent);
+
+				assertHighlightEquals(sb.toString(), actualContent);
+			}
+			else {
+				_assertSpaceResult(
+					highlightedContent, normalContent, i, actualContent);
+			}
+		}
 	}
 
 	@Test
@@ -71,15 +181,37 @@ public class SummaryBuilderImplTest {
 
 		_summaryBuilder.setEscape(false);
 		_summaryBuilder.setHighlight(true);
+		_summaryBuilder.setMaxContentLength(200);
 
 		Summary summary = _summaryBuilder.build();
 
-		Assert.assertEquals(
-			StringBundler.concat(
-				"AAA<strong>BBB</strong>CCC", HighlightUtil.HIGHLIGHTS[0],
-				"DDD<strong>EEE</strong>FFF", HighlightUtil.HIGHLIGHTS[1],
-				"GGG<strong>HHH</strong>III"),
+		assertHighlightEquals(
+			"AAA<strong>BBB</strong>CCC[[DDD<strong>EEE</strong>FFF" +
+				"]]GGG<strong>HHH</strong>III",
 			summary.getContent());
+	}
+
+	@Test
+	public void testHighlightWithCarrot() {
+		StringBundler sb = new StringBundler(3);
+		String normalContent = RandomTestUtil.randomString(11);
+
+		sb.append(normalContent);
+
+		sb.append("<");
+		sb.append(normalContent);
+
+		String content = sb.toString();
+
+		_summaryBuilder.setContent(content);
+
+		_summaryBuilder.setMaxContentLength(8);
+
+		Summary summary = _summaryBuilder.build();
+
+		String expectedContent = content.substring(0, 5) + "...";
+
+		assertHighlightEquals(expectedContent, summary.getContent());
 	}
 
 	@Test
@@ -110,21 +242,6 @@ public class SummaryBuilderImplTest {
 	}
 
 	@Test
-	public void testMaxContentLengthIgnoredWhenHighlight() {
-		String content = RandomTestUtil.randomString(8);
-
-		_summaryBuilder.setContent(content);
-
-		_summaryBuilder.setHighlight(true);
-
-		_summaryBuilder.setMaxContentLength(1);
-
-		Summary summary = _summaryBuilder.build();
-
-		Assert.assertEquals(content, summary.getContent());
-	}
-
-	@Test
 	public void testTitle() {
 		String title = RandomTestUtil.randomString();
 
@@ -147,13 +264,10 @@ public class SummaryBuilderImplTest {
 
 		Summary summary = _summaryBuilder.build();
 
-		Assert.assertEquals(
-			StringBundler.concat(
-				"AAA&lt;strong&gt;BBB&lt;/strong&gt;CCC",
-				HighlightUtil.HIGHLIGHTS[0],
-				"DDD&lt;strong&gt;EEE&lt;/strong&gt;FFF",
-				HighlightUtil.HIGHLIGHTS[1],
-				"GGG&lt;strong&gt;HHH&lt;/strong&gt;III"),
+		assertHighlightEquals(
+			"AAA&lt;strong&gt;BBB&lt;/strong&gt;CCC[[DDD&lt;strong" +
+				"&gt;EEE&lt;/strong&gt;FFF]]GGG&lt;strong&gt;HHH&lt;" +
+					"/strong&gt;III",
 			summary.getTitle());
 	}
 
@@ -170,12 +284,17 @@ public class SummaryBuilderImplTest {
 
 		Summary summary = _summaryBuilder.build();
 
-		Assert.assertEquals(
-			StringBundler.concat(
-				"AAA<strong>BBB</strong>CCC", HighlightUtil.HIGHLIGHTS[0],
-				"DDD<strong>EEE</strong>FFF", HighlightUtil.HIGHLIGHTS[1],
-				"GGG<strong>HHH</strong>III"),
+		assertHighlightEquals(
+			"AAA<strong>BBB</strong>CCC[[DDD<strong>EEE</strong>FFF" +
+				"]]GGG<strong>HHH</strong>III",
 			summary.getTitle());
+	}
+
+	protected void assertHighlightEquals(String expected, String s) {
+		expected = StringUtil.replace(
+			expected, new String[] {"[[", "]]"}, HighlightUtil.HIGHLIGHTS);
+
+		Assert.assertEquals(expected, s);
 	}
 
 	protected void testMaxContentLength(
@@ -189,6 +308,69 @@ public class SummaryBuilderImplTest {
 		Summary summary = summaryBuilder.build();
 
 		Assert.assertEquals(expected, summary.getContent());
+	}
+
+	private void _assertNoSpaceResult(
+		String highlightedContent, String normalContent, int maxLength,
+		String result) {
+
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("[[");
+
+		if (maxLength < (highlightedContent.length() + 3)) {
+			sb.append(highlightedContent.substring(0, maxLength - 3));
+		}
+		else {
+			sb.append(highlightedContent);
+		}
+
+		sb.append("]]");
+
+		if (maxLength > (highlightedContent.length() + 3)) {
+			sb.append(
+				normalContent.substring(
+					0, maxLength - highlightedContent.length() - 3));
+		}
+
+		sb.append("...");
+
+		assertHighlightEquals(sb.toString(), result);
+	}
+
+	private void _assertSpaceResult(
+		String highlightedContent, String normalContent, int maxLength,
+		String result) {
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append("[[");
+
+		if (maxLength < (highlightedContent.length() + 3)) {
+			sb.append(highlightedContent.substring(0, maxLength - 3));
+		}
+		else {
+			sb.append(highlightedContent);
+		}
+
+		if (maxLength > (highlightedContent.length() * 2 + 3)) {
+			sb.append(" ");
+			sb.append(highlightedContent);
+		}
+
+		sb.append("]]");
+
+		if (maxLength >
+				(highlightedContent.
+					length() * 2 + normalContent.length() + 4)) {
+
+			sb.append(" ");
+			sb.append(normalContent);
+		}
+
+		sb.append("...");
+
+		assertHighlightEquals(sb.toString(), result);
 	}
 
 	private final SummaryBuilder _summaryBuilder = new SummaryBuilderImpl();

--- a/portal-impl/src/com/liferay/portal/search/PortalOpenSearchImpl.java
+++ b/portal-impl/src/com/liferay/portal/search/PortalOpenSearchImpl.java
@@ -146,7 +146,7 @@ public class PortalOpenSearchImpl extends BaseOpenSearchImpl {
 
 					title = summary.getTitle();
 					url = portletURL.toString();
-					content = summary.getContent();
+					content = summary.getFullContent();
 				}
 
 				double score = results.score(i);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -535,7 +535,7 @@ public class DLFileEntryIndexer
 		Summary summary = createSummary(
 			locale, document, Field.TITLE, Field.CONTENT);
 
-		if (Validator.isNull(summary.getContent())) {
+		if (Validator.isNull(summary.getFullContent())) {
 			summary = createSummary(document, Field.TITLE, Field.DESCRIPTION);
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Summary.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Summary.java
@@ -65,6 +65,10 @@ public class Summary {
 		return _content;
 	}
 
+	public String getFullContent() {
+		return _content;
+	}
+
 	public String getHighlightedContent() {
 		return _escapeAndHighlight(_content);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 7.6.0
+version 7.7.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -3449,7 +3449,7 @@ public class StringUtil {
 		for (int j = curLength - suffix.length() + 1, offset; j > 0; j--) {
 			offset = s.offsetByCodePoints(0, j);
 
-			if (Character.isWhitespace(s.codePointBefore(offset))) {
+			if (Character.isSpaceChar(s.codePointBefore(offset))) {
 				curLength = j - 1;
 
 				break;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-83186
https://issues.liferay.com/browse/LPS-83181

These tickets are pretty well entangled at this point.

For LPS-83181, 
> A common cause of this problem is the body of the Message Board contained "& nbsp;" as it's whitespace and the StringUtil.shorten() method does not see "& nbsp;" as a place to break, so it just defaults to cutting the text at the character limit.

>StringUtil used Character.isWhitespace() to find word ends when shortening text, however that method looks for what Java considers a space and will not find non-breaking spaces as is stated in it's [description](https://docs.oracle.com/javase/7/docs/api/java/lang/Character.html#isWhitespace(char)). The better method to use is Character.isSpaceChar() which finds whitespace characters based on Unicode standards which is more appropriate, description [here](https://docs.oracle.com/javase/7/docs/api/java/lang/Character.html#isSpaceChar(char)). 

>I added a _shortenHighlightedContent() and also check to make sure there is always an enclosing highlight tag.

For LPS-73186

>The core issue is that highlighting tags in search snippets were being counted towards the max content size even though the tags do not take up any visual room.

>The idea of the code is to base the length on what will be visually shown by looking at the size of the content after stripping out the highlight tags. I added _recalculateHighlightMaxLength() which sums up all the addition characters used by the Highlight tags. _shortenHighlightedContent() then uses this virtual size to shorten the content accordingly.

> Lastly I noticed that the highlights of CalendarBookings were being stripped. I believe this is unintentional as it does not match the behavior of any other assets, so I corrected them to maintain highlights in the same fashion as Journal Articles.