### PR TITLE
LPS-92008 Make search widgets invisible before performing search

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/ModifiedFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/ModifiedFacetPortlet.java
@@ -93,6 +93,11 @@ public class ModifiedFacetPortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			WebKeys.PORTLET_DISPLAY_CONTEXT, modifiedFacetDisplayContext);
 
+		if (modifiedFacetDisplayContext.isRenderNothing()) {
+			renderRequest.setAttribute(
+				WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+		}
+
 		super.render(renderRequest, renderResponse);
 	}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
@@ -116,6 +116,11 @@ public class SearchResultsPortlet extends MVCPortlet {
 			WebKeys.PORTLET_DISPLAY_CONTEXT,
 			searchResultsPortletDisplayContext);
 
+		if (searchResultsPortletDisplayContext.isRenderNothing()) {
+			renderRequest.setAttribute(
+				WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+		}
+
 		super.render(renderRequest, renderResponse);
 	}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/SuggestionsPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/SuggestionsPortlet.java
@@ -92,6 +92,13 @@ public class SuggestionsPortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			WebKeys.PORTLET_DISPLAY_CONTEXT, suggestionsPortletDisplayContext);
 
+		if (!suggestionsPortletDisplayContext.hasSpellCheckSuggestion() &&
+			!suggestionsPortletDisplayContext.hasRelatedQueriesSuggestions()) {
+
+			renderRequest.setAttribute(
+				WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+		}
+
 		super.render(renderRequest, renderResponse);
 	}
 


### PR DESCRIPTION
This change fixes 2 tickets:
http://issues.liferay.com/browse/LPS-92008
https://issues.liferay.com/browse/LPS-81279

We decided to leave custom filter as-is (still showing when there are no results) since the portlet contents aren't based on the amounts of results shown. Also, I'm not sure how much effort it would be to tie in the total result count into the portlet, so it overall didn't seem worth implementing to be able to hide the portlet when there are no results.