### PR TITLE
LPS-92782 New API needed for result rankings

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexSearcher.java
@@ -411,6 +411,8 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 		baseSearchRequest.setExplain(searchRequest.isExplain());
 		baseSearchRequest.setIncludeResponseString(
 			searchRequest.isIncludeResponseString());
+		baseSearchRequest.setMainQueryInShouldClause(
+			searchRequest.isMainQueryInShouldClause());
 		baseSearchRequest.setPostFilterQuery(
 			searchRequest.getPostFilterQuery());
 		baseSearchRequest.setRescoreQuery(searchRequest.getRescoreQuery());

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/IdsQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/IdsQueryTranslatorImpl.java
@@ -34,9 +34,15 @@ public class IdsQueryTranslatorImpl implements IdsQueryTranslator {
 	public QueryBuilder translate(IdsQuery idsQuery) {
 		IdsQueryBuilder idsQueryBuilder = QueryBuilders.idsQuery();
 
+		if (idsQuery.getBoost() != null) {
+			idsQueryBuilder.boost(idsQuery.getBoost());
+		}
+
 		Set<String> ids = idsQuery.getIds();
 
 		idsQueryBuilder.addIds(ids.toArray(new String[0]));
+
+		idsQueryBuilder.queryName(idsQuery.getQueryName());
 
 		Set<String> types = idsQuery.getTypes();
 

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/CommonSearchRequestBuilderAssemblerImpl.java
@@ -80,7 +80,8 @@ public class CommonSearchRequestBuilderAssemblerImpl
 	}
 
 	protected QueryBuilder combine(
-		QueryBuilder queryBuilder, List<ComplexQueryPart> complexQueryParts) {
+		QueryBuilder queryBuilder, List<ComplexQueryPart> complexQueryParts,
+		boolean mainQueryInShouldClause) {
 
 		if (complexQueryParts.isEmpty()) {
 			return queryBuilder;
@@ -89,7 +90,12 @@ public class CommonSearchRequestBuilderAssemblerImpl
 		BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
 
 		if (queryBuilder != null) {
-			boolQueryBuilder.must(queryBuilder);
+			if (mainQueryInShouldClause) {
+				boolQueryBuilder.should(queryBuilder);
+			}
+			else {
+				boolQueryBuilder.must(queryBuilder);
+			}
 		}
 
 		BooleanQuery booleanQuery =
@@ -149,7 +155,8 @@ public class CommonSearchRequestBuilderAssemblerImpl
 			queryBuilder, legacyQueryBuilder);
 
 		return combine(
-			combinedQueryBuilder, baseSearchRequest.getComplexQueryParts());
+			combinedQueryBuilder, baseSearchRequest.getComplexQueryParts(),
+			baseSearchRequest.getMainQueryInShouldClause());
 	}
 
 	protected void setAggregations(

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchRequest.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchRequest.java
@@ -116,4 +116,6 @@ public interface SearchRequest {
 	 */
 	public boolean isIncludeResponseString();
 
+	public boolean isMainQueryInShouldClause();
+
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchRequestBuilder.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchRequestBuilder.java
@@ -120,6 +120,9 @@ public interface SearchRequestBuilder {
 
 	public SearchRequestBuilder indexes(String... indexes);
 
+	public SearchRequestBuilder mainQueryInShouldClause(
+		boolean mainQueryInShouldClause);
+
 	public SearchRequestBuilder modelIndexerClasses(Class<?>... classes);
 
 	public void paginationStartParameterName(

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/searcher/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/searcher/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/search/BaseSearchRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/search/BaseSearchRequest.java
@@ -82,6 +82,10 @@ public abstract class BaseSearchRequest {
 		return _indexNames;
 	}
 
+	public boolean getMainQueryInShouldClause() {
+		return _mainQueryInShouldClause;
+	}
+
 	public Float getMinimumScore() {
 		return _minimumScore;
 	}
@@ -186,6 +190,10 @@ public abstract class BaseSearchRequest {
 		_indexNames = indexNames;
 	}
 
+	public void setMainQueryInShouldClause(boolean mainQueryInShouldClause) {
+		_mainQueryInShouldClause = mainQueryInShouldClause;
+	}
+
 	public void setMinimumScore(Float minimumScore) {
 		_minimumScore = minimumScore;
 	}
@@ -240,6 +248,7 @@ public abstract class BaseSearchRequest {
 	private final Map<String, Float> _indexBoosts = new LinkedHashMap<>();
 	private String[] _indexNames;
 	private com.liferay.portal.kernel.search.Query _legacyQuery;
+	private boolean _mainQueryInShouldClause;
 	private Float _minimumScore;
 	private final Map<String, PipelineAggregation> _pipelineAggregationsMap =
 		new LinkedHashMap<>();

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/resources/com/liferay/portal/search/engine/adapter/search/packageinfo
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/resources/com/liferay/portal/search/engine/adapter/search/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
@@ -143,16 +143,7 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 				return null;
 			}
 
-			Query query = getQuery(complexQueryPart);
-
-			if (query == null) {
-				return null;
-			}
-
-			query.setBoost(complexQueryPart.getBoost());
-			query.setQueryName(complexQueryPart.getName());
-
-			return query;
+			return getQuery(complexQueryPart);
 		}
 
 		protected Query buildQuery(String type, String field, String value) {
@@ -307,7 +298,14 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 			String type = GetterUtil.getString(complexQueryPart.getType());
 			String value = GetterUtil.getString(complexQueryPart.getValue());
 
-			return buildQuery(type, field, value);
+			Query query = buildQuery(type, field, value);
+
+			if (query != null) {
+				query.setBoost(complexQueryPart.getBoost());
+				query.setQueryName(complexQueryPart.getName());
+			}
+
+			return query;
 		}
 
 		protected BooleanQuery getRootBooleanQuery() {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/legacy/searcher/SearchRequestBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/legacy/searcher/SearchRequestBuilderImpl.java
@@ -280,6 +280,17 @@ public class SearchRequestBuilderImpl implements SearchRequestBuilder {
 	}
 
 	@Override
+	public SearchRequestBuilder mainQueryInShouldClause(
+		boolean mainQueryInShouldClause) {
+
+		withSearchRequestImpl(
+			searchRequestImpl -> searchRequestImpl.setMainQueryInShouldClause(
+				mainQueryInShouldClause));
+
+		return this;
+	}
+
+	@Override
 	public SearchRequestBuilder modelIndexerClasses(Class<?>... classes) {
 		withSearchRequestImpl(
 			searchRequestImpl -> searchRequestImpl.setModelIndexerClasses(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchRequestImpl.java
@@ -66,6 +66,7 @@ public class SearchRequestImpl implements SearchRequest, Serializable {
 		_groupByRequests.addAll(searchRequestImpl._groupByRequests);
 		_includeContributors.addAll(searchRequestImpl._includeContributors);
 		_includeResponseString = searchRequestImpl._includeResponseString;
+		_mainQueryInShouldClause = searchRequestImpl._mainQueryInShouldClause;
 		_modelIndexerClasses.addAll(searchRequestImpl._modelIndexerClasses);
 		_pipelineAggregationsMap.putAll(
 			searchRequestImpl._pipelineAggregationsMap);
@@ -251,6 +252,11 @@ public class SearchRequestImpl implements SearchRequest, Serializable {
 		return _includeResponseString;
 	}
 
+	@Override
+	public boolean isMainQueryInShouldClause() {
+		return _mainQueryInShouldClause;
+	}
+
 	public void setBasicFacetSelection(boolean basicFacetSelection) {
 		_basicFacetSelection = basicFacetSelection;
 
@@ -305,6 +311,10 @@ public class SearchRequestImpl implements SearchRequest, Serializable {
 		QueryConfig queryConfig = _searchContext.getQueryConfig();
 
 		queryConfig.setSelectedIndexNames(indexes);
+	}
+
+	public void setMainQueryInShouldClause(boolean mainQueryInShouldClause) {
+		_mainQueryInShouldClause = mainQueryInShouldClause;
 	}
 
 	public void setModelIndexerClasses(Class<?>... classes) {
@@ -371,6 +381,7 @@ public class SearchRequestImpl implements SearchRequest, Serializable {
 	private final List<GroupByRequest> _groupByRequests = new ArrayList<>();
 	private final List<String> _includeContributors = new ArrayList<>();
 	private boolean _includeResponseString;
+	private boolean _mainQueryInShouldClause;
 	private final List<Class<?>> _modelIndexerClasses = new ArrayList<>();
 	private String _paginationStartParameterName;
 	private final Map<String, PipelineAggregation> _pipelineAggregationsMap =


### PR DESCRIPTION
For an "added" result (ie pinning a document titled "bravo" in search results for "alpha"), we need an IdsQuery that is *separate* from the main query (since the main query wont match anything titled "bravo"), meaning we need "root" level OR logic. This is kind of related to https://issues.liferay.com/browse/LPS-98297. This pr adds a flag that can give us the OR behavior. 

---
*[Story] As a Search Admin, I want to reorder pins in a Ranking*
https://issues.liferay.com/browse/LPS-92782