### PR TITLE
 [TECHNICAL-SUPPORT] LPS-100523

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5545,8 +5545,8 @@ public class JournalArticleLocalServiceImpl
 						treePathProperty.ne(treePath)));
 			});
 
-		final Indexer<JournalArticle> indexer = IndexerRegistryUtil.getIndexer(
-			JournalArticle.class.getName());
+		final Indexer<JournalArticle> indexer =
+			IndexerRegistryUtil.nullSafeGetIndexer(JournalArticle.class);
 
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(JournalArticle article) -> {
@@ -5554,7 +5554,7 @@ public class JournalArticleLocalServiceImpl
 
 				updateJournalArticle(article);
 
-				if (!reindex) {
+				if (!reindex || !indexer.isIndexerEnabled()) {
 					return;
 				}
 
@@ -7277,9 +7277,6 @@ public class JournalArticleLocalServiceImpl
 		IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			getIndexableActionableDynamicQuery();
 
-		Indexer<JournalArticle> indexer = IndexerRegistryUtil.getIndexer(
-			JournalArticle.class);
-
 		indexableActionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
 				Property classNameIdProperty = PropertyFactoryUtil.forName(
@@ -7300,6 +7297,10 @@ public class JournalArticleLocalServiceImpl
 					statusProperty.eq(WorkflowConstants.STATUS_APPROVED));
 			});
 		indexableActionableDynamicQuery.setCompanyId(companyId);
+
+		final Indexer<JournalArticle> indexer =
+			IndexerRegistryUtil.nullSafeGetIndexer(JournalArticle.class);
+
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(JournalArticle article) -> {
 				if (_log.isDebugEnabled()) {
@@ -7336,7 +7337,7 @@ public class JournalArticleLocalServiceImpl
 
 				updatePreviousApprovedArticle(article);
 
-				if (indexer != null) {
+				if (indexer.isIndexerEnabled()) {
 					indexableActionableDynamicQuery.addDocuments(
 						indexer.getDocument(article));
 				}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -4687,6 +4687,10 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		final Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			User.class);
 
+		if (!indexer.isIndexerEnabled()) {
+			return;
+		}
+
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			userLocalService.getIndexableActionableDynamicQuery();
 

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -2316,6 +2316,10 @@ public class OrganizationLocalServiceImpl
 		final Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			User.class);
 
+		if (!indexer.isIndexerEnabled()) {
+			return;
+		}
+
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			userLocalService.getIndexableActionableDynamicQuery();
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -1211,6 +1211,10 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		final Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			User.class);
 
+		if (!indexer.isIndexerEnabled()) {
+			return;
+		}
+
 		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			userLocalService.getIndexableActionableDynamicQuery();
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -571,15 +571,19 @@ public class DLAppHelperLocalServiceImpl
 	public void reindex(long companyId, List<Long> dlFileEntryIds)
 		throws PortalException {
 
+		final Indexer<DLFileEntry> indexer =
+			IndexerRegistryUtil.nullSafeGetIndexer(DLFileEntry.class);
+
+		if (!indexer.isIndexerEnabled()) {
+			return;
+		}
+
 		IntervalActionProcessor<Void> intervalActionProcessor =
 			new IntervalActionProcessor<>(dlFileEntryIds.size());
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
 			(start, end) -> {
 				List<Long> sublist = dlFileEntryIds.subList(start, end);
-
-				Indexer<DLFileEntry> indexer =
-					IndexerRegistryUtil.nullSafeGetIndexer(DLFileEntry.class);
 
 				IndexableActionableDynamicQuery
 					indexableActionableDynamicQuery =

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1781,8 +1781,8 @@ public class DLFileEntryLocalServiceImpl
 						treePathProperty.ne(treePath)));
 			});
 
-		Indexer<DLFileEntry> indexer = IndexerRegistryUtil.getIndexer(
-			DLFileEntry.class.getName());
+		final Indexer<DLFileEntry> indexer =
+			IndexerRegistryUtil.nullSafeGetIndexer(DLFileEntry.class);
 
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(DLFileEntry dlFileEntry) -> {
@@ -1790,7 +1790,7 @@ public class DLFileEntryLocalServiceImpl
 
 				updateDLFileEntry(dlFileEntry);
 
-				if (!reindex) {
+				if (!reindex || !indexer.isIndexerEnabled()) {
 					return;
 				}
 


### PR DESCRIPTION
Hi @arboliveira,

maybe Inside of IndexableActionableDynamicQuery we can just do something like:
```
public void performActions() throws PortalException {
	Indexer<?> indexer = IndexerRegistryUtil.getIndexer(getModelClass());

	if (!indexer.isIndexerEnabled()) {
		return;
	}
```

I see there's some usage in DL where it has a separate reindex flag but we could just rewrite that part to get a separate ActionableDynamicQuery not made for indexing when the flag is not set.