### PR TITLE
LPS-100673 (+2 issues) FIX Ids Query is disregarding boost attribute

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/IdsQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/query/IdsQueryTranslatorImpl.java
@@ -34,9 +34,15 @@ public class IdsQueryTranslatorImpl implements IdsQueryTranslator {
 	public QueryBuilder translate(IdsQuery idsQuery) {
 		IdsQueryBuilder idsQueryBuilder = QueryBuilders.idsQuery();
 
+		if (idsQuery.getBoost() != null) {
+			idsQueryBuilder.boost(idsQuery.getBoost());
+		}
+
 		Set<String> ids = idsQuery.getIds();
 
 		idsQueryBuilder.addIds(ids.toArray(new String[0]));
+
+		idsQueryBuilder.queryName(idsQuery.getQueryName());
 
 		Set<String> types = idsQuery.getTypes();
 

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/filter/ComplexQueryPart.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/filter/ComplexQueryPart.java
@@ -40,6 +40,8 @@ public interface ComplexQueryPart {
 
 	public String getValue();
 
+	public boolean isAdditive();
+
 	public boolean isDisabled();
 
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/filter/ComplexQueryPartBuilder.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/filter/ComplexQueryPartBuilder.java
@@ -24,6 +24,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ComplexQueryPartBuilder {
 
+	public ComplexQueryPartBuilder additive(boolean additive);
+
 	public ComplexQueryPartBuilder boost(Float boost);
 
 	public ComplexQueryPart build();

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/filter/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/filter/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderImpl.java
@@ -108,7 +108,7 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 		}
 
 		protected Query addQuery(ComplexQueryPart complexQueryPart) {
-			Query query = buildQuery(complexQueryPart);
+			Query query = getQuery(complexQueryPart);
 
 			if (query == null) {
 				return null;
@@ -136,23 +136,6 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 			else if (Objects.equals("should", occur)) {
 				booleanQuery.addShouldQueryClauses(query);
 			}
-		}
-
-		protected Query buildQuery(ComplexQueryPart complexQueryPart) {
-			if (complexQueryPart.isDisabled()) {
-				return null;
-			}
-
-			Query query = getQuery(complexQueryPart);
-
-			if (query == null) {
-				return null;
-			}
-
-			query.setBoost(complexQueryPart.getBoost());
-			query.setQueryName(complexQueryPart.getName());
-
-			return query;
 		}
 
 		protected Query buildQuery(String type, String field, String value) {
@@ -299,15 +282,30 @@ public class ComplexQueryBuilderImpl implements ComplexQueryBuilder {
 		}
 
 		protected Query getQuery(ComplexQueryPart complexQueryPart) {
+			if (complexQueryPart.isDisabled()) {
+				return null;
+			}
+
 			if (complexQueryPart.getQuery() != null) {
 				return complexQueryPart.getQuery();
 			}
 
-			String field = GetterUtil.getString(complexQueryPart.getField());
 			String type = GetterUtil.getString(complexQueryPart.getType());
+
+			String field = GetterUtil.getString(complexQueryPart.getField());
+
 			String value = GetterUtil.getString(complexQueryPart.getValue());
 
-			return buildQuery(type, field, value);
+			Query query = buildQuery(type, field, value);
+
+			if (query == null) {
+				return null;
+			}
+
+			query.setBoost(complexQueryPart.getBoost());
+			query.setQueryName(complexQueryPart.getName());
+
+			return query;
 		}
 
 		protected BooleanQuery getRootBooleanQuery() {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryPartImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryPartImpl.java
@@ -27,6 +27,7 @@ public class ComplexQueryPartImpl implements ComplexQueryPart {
 	}
 
 	public ComplexQueryPartImpl(ComplexQueryPartImpl complexQueryPartImpl) {
+		_additive = complexQueryPartImpl._additive;
 		_boost = complexQueryPartImpl._boost;
 		_disabled = complexQueryPartImpl._disabled;
 		_field = complexQueryPartImpl._field;
@@ -79,11 +80,23 @@ public class ComplexQueryPartImpl implements ComplexQueryPart {
 	}
 
 	@Override
+	public boolean isAdditive() {
+		return _additive;
+	}
+
+	@Override
 	public boolean isDisabled() {
 		return _disabled;
 	}
 
 	public static class Builder implements ComplexQueryPartBuilder {
+
+		@Override
+		public ComplexQueryPartBuilder additive(boolean additive) {
+			_complexQueryPartImpl._additive = additive;
+
+			return this;
+		}
 
 		@Override
 		public ComplexQueryPartBuilder boost(Float boost) {
@@ -158,6 +171,7 @@ public class ComplexQueryPartImpl implements ComplexQueryPart {
 
 	}
 
+	private boolean _additive;
 	private Float _boost;
 	private boolean _disabled;
 	private String _field;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchResponseImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchResponseImpl.java
@@ -75,11 +75,19 @@ public class SearchResponseImpl implements SearchResponse, Serializable {
 
 	@Override
 	public List<com.liferay.portal.kernel.search.Document> getDocuments71() {
+		if (_hits == null) {
+			return Collections.emptyList();
+		}
+
 		return Arrays.asList(_hits.getDocs());
 	}
 
 	@Override
 	public Stream<Document> getDocumentsStream() {
+		if (_searchHits == null) {
+			return Stream.empty();
+		}
+
 		List<SearchHit> list = _searchHits.getSearchHits();
 
 		return list.stream(
@@ -142,6 +150,10 @@ public class SearchResponseImpl implements SearchResponse, Serializable {
 
 	@Override
 	public int getTotalHits() {
+		if (_hits == null) {
+			return 0;
+		}
+
 		return _hits.getLength();
 	}
 
@@ -231,7 +243,7 @@ public class SearchResponseImpl implements SearchResponse, Serializable {
 		new LinkedHashMap<>();
 	private long _count;
 	private final FacetContextImpl _facetContext;
-	private String _federatedSearchKey;
+	private String _federatedSearchKey = StringPool.BLANK;
 	private final Map<String, SearchResponse> _federatedSearchResponsesMap =
 		new LinkedHashMap<>();
 	private final List<GroupByResponse> _groupByResponses = new ArrayList<>();

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/SearchResponseImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/SearchResponseImplTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.searcher;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.search.searcher.SearchResponse;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author André de Oliveira
+ */
+public class SearchResponseImplTest {
+
+	@Test
+	public void testDefaultsAreNullSafe() {
+		SearchResponse searchResponse = new SearchResponseImpl(
+			new SearchContext());
+
+		assertIs(searchResponse.getAggregationResult(null), nullValue());
+		assertIs(searchResponse.getAggregationResultsMap(), emptyMap());
+		assertIs(searchResponse.getCount(), zeroLong());
+		assertIs(searchResponse.getDocuments71(), emptyList());
+		assertIs(searchResponse.getDocumentsStream(), emptyStream());
+		assertIs(searchResponse.getFederatedSearchKey(), blank());
+		assertIs(
+			searchResponse.getFederatedSearchResponse(null),
+			same(searchResponse));
+		assertIs(
+			searchResponse.getFederatedSearchResponsesStream(), emptyStream());
+		assertIs(searchResponse.getGroupByResponses(), emptyList());
+		assertIs(searchResponse.getRequest(), nullValue());
+		assertIs(searchResponse.getRequestString(), blank());
+		assertIs(searchResponse.getResponseString(), blank());
+		assertIs(searchResponse.getSearchHits(), nullValue());
+		assertIs(searchResponse.getStatsResponseMap(), emptyMap());
+		assertIs(searchResponse.getTotalHits(), zeroInt());
+	}
+
+	protected static <T> void assertIs(T actual, Consumer<T> consumer) {
+		consumer.accept(actual);
+	}
+
+	protected static Consumer blank() {
+		return string -> Assert.assertEquals(StringPool.BLANK, string);
+	}
+
+	protected static Consumer<List> emptyList() {
+		return list -> Assert.assertEquals("[]", String.valueOf(list));
+	}
+
+	protected static Consumer<Map> emptyMap() {
+		return map -> Assert.assertEquals("{}", String.valueOf(map));
+	}
+
+	protected static Consumer<Stream> emptyStream() {
+		return stream -> Assert.assertEquals(
+			"[]",
+			String.valueOf(
+				stream.map(
+					String::valueOf
+				).collect(
+					Collectors.toList()
+				)));
+	}
+
+	protected static Consumer nullValue() {
+		return object -> Assert.assertNull(object);
+	}
+
+	protected static Consumer same(Object expected) {
+		return actual -> Assert.assertSame(expected, actual);
+	}
+
+	protected static Consumer<Integer> zeroInt() {
+		return value -> Assert.assertEquals(0, value.intValue());
+	}
+
+	protected static Consumer<Long> zeroLong() {
+		return value -> Assert.assertEquals(0, value.longValue());
+	}
+
+}


### PR DESCRIPTION


----

Authors: BryanEngler @arboliveira
Reviewer: @arboliveira

----

_[Story] Search API: Additive Complex Query Parts_
https://issues.liferay.com/browse/LPS-100667

_[Bug] Ids Query is disregarding boost attribute_
https://issues.liferay.com/browse/LPS-100673

_[Bug] SearchResponseImpl is not null safe under certain API usage scenarios, leading to NullPointerException_
https://issues.liferay.com/browse/LPS-100676
