### PR TITLE
LPS-102149 FIX: Search integration tests fail when a randomly chosen keyword contains a number, the substring "to", then another number

### DIFF
--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/DocumentsAssert.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/DocumentsAssert.java
@@ -14,7 +14,9 @@
 
 package com.liferay.portal.search.test.util;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.document.Document;
 
 import java.util.ArrayList;
@@ -83,8 +85,9 @@ public class DocumentsAssert {
 		List<String> actualValues = _getFieldValueStrings(fieldName, documents);
 
 		Assert.assertEquals(
-			message + "->" + actualValues, _sort(expectedValues),
-			_sort(actualValues));
+			StringBundler.concat(
+				message, "->", StringUtil.merge(documents), "->", actualValues),
+			_sort(expectedValues), _sort(actualValues));
 	}
 
 	public static void assertValuesIgnoreRelevance(

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetEntriesFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetEntriesFacetedSearcherTest.java
@@ -98,6 +98,30 @@ public class AssetEntriesFacetedSearcherTest
 	}
 
 	@Test
+	public void testAvoidResidualDataFromDDMStructureLocalServiceTest()
+		throws Exception {
+
+		// See LPS-58543
+
+		String keyword = "To Do";
+
+		index(keyword);
+
+		SearchContext searchContext = getSearchContext(keyword);
+
+		Facet facet = createFacet(searchContext);
+
+		searchContext.addFacet(facet);
+
+		Hits hits = search(searchContext);
+
+		assertEntryClassNames(_entryClassNames, hits, facet, searchContext);
+
+		assertFrequencies(
+			facet.getFieldName(), searchContext, toMap(_entryClassNames));
+	}
+
+	@Test
 	public void testSelection() throws Exception {
 		String keyword = RandomTestUtil.randomString();
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/CategoryFacetTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/CategoryFacetTest.java
@@ -21,6 +21,7 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -91,12 +92,46 @@ public class CategoryFacetTest extends BaseFacetedSearcherTestCase {
 
 		searchContext.addFacet(facet);
 
-		search(searchContext);
+		Hits hits = search(searchContext);
 
 		Map<String, Integer> frequencies = Collections.singletonMap(
 			String.valueOf(categoryId), 1);
 
-		assertFrequencies(facet.getFieldName(), searchContext, frequencies);
+		assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
+	}
+
+	@Test
+	public void testAvoidResidualDataFromDDMStructureLocalServiceTest()
+		throws Exception {
+
+		// See LPS-58543
+
+		String title = "To Do";
+
+		AssetCategory assetCategory = addCategory(title);
+
+		long categoryId = assetCategory.getCategoryId();
+
+		addUser(_group, categoryId);
+
+		SearchContext searchContext = getSearchContext(
+			assetCategory.getTitleCurrentValue());
+
+		searchContext.setCategoryIds(new long[] {categoryId});
+		searchContext.setGroupIds(new long[] {_group.getGroupId()});
+
+		Facet facet = categoryFacetFactory.newInstance(searchContext);
+
+		searchContext.addFacet(facet);
+
+		Hits hits = search(searchContext);
+
+		Map<String, Integer> frequencies = Collections.singletonMap(
+			String.valueOf(categoryId), 1);
+
+		assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
 	}
 
 	protected AssetCategory addCategory(String title) throws Exception {

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetedSearcherTest.java
@@ -52,7 +52,11 @@ public class FacetedSearcherTest extends BaseFacetedSearcherTestCase {
 
 		User user = addUser(group, tag);
 
-		assertSearch(tag, toMap(user, tag));
+		SearchContext searchContext = getSearchContext(tag);
+
+		Map<String, String> expected = toMap(user, tag);
+
+		assertTags(tag, expected, searchContext);
 	}
 
 	@Test
@@ -71,22 +75,33 @@ public class FacetedSearcherTest extends BaseFacetedSearcherTestCase {
 
 		User user2 = addUser(group2, tag2);
 
-		assertSearch(
+		assertSearchGroupIdsUnset(
 			prefix, SearchMapUtil.join(toMap(user1, tag1), toMap(user2, tag2)));
 
 		deactivate(group1);
 
-		assertSearch(prefix, toMap(user2, tag2));
+		assertSearchGroupIdsUnset(prefix, toMap(user2, tag2));
 
 		deactivate(group2);
 
-		assertSearch(prefix, Collections.<String, String>emptyMap());
+		assertSearchGroupIdsUnset(
+			prefix, Collections.<String, String>emptyMap());
 	}
 
-	protected void assertSearch(String keywords, Map<String, String> expected)
+	protected void assertSearchGroupIdsUnset(
+			String keywords, Map<String, String> expected)
 		throws Exception {
 
-		SearchContext searchContext = getSearchContext(keywords);
+		SearchContext searchContext = getSearchContextWithGroupIdsUnset(
+			keywords);
+
+		assertTags(keywords, expected, searchContext);
+	}
+
+	protected void assertTags(
+			String keywords, Map<String, String> expected,
+			SearchContext searchContext)
+		throws Exception {
 
 		Hits hits = search(searchContext);
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
@@ -119,6 +119,39 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 	}
 
 	@Test
+	public void testAvoidResidualDataFromDDMStructureLocalServiceTest()
+		throws Exception {
+
+		// See LPS-58543
+
+		String keyword = "To Do";
+
+		index(keyword);
+
+		SearchContext searchContext = getSearchContext(keyword);
+
+		Facet facet = folderFacetFactory.newInstance(searchContext);
+
+		searchContext.addFacet(facet);
+
+		Hits hits = search(searchContext);
+
+		Assert.assertEquals(hits.toString(), 3, hits.getLength());
+
+		List<String> entryClassNames = Arrays.asList(
+			DLFolder.class.getName(), DLFileEntry.class.getName(),
+			User.class.getName());
+
+		assertEntryClassNames(entryClassNames, hits, facet, searchContext);
+
+		List<String> dlFolderIds = Arrays.asList(
+			ArrayUtil.append(getFolderIds(_dlFolders), "0"));
+
+		assertFrequencies(
+			facet.getFieldName(), searchContext, toMap(dlFolderIds, 1));
+	}
+
+	@Test
 	public void testSelection() throws Exception {
 		String keyword = RandomTestUtil.randomString();
 

--- a/test.properties
+++ b/test.properties
@@ -1070,7 +1070,6 @@
 
     test.batch.class.names.excludes.temporary=\
         **/portal-search-elasticsearch7/**/*Test.java,\
-        **/portal-search-test/**/com/liferay/portal/search/facet/faceted/searcher/test/*Test.java,\
         modules/apps/archived/mail-reader-test/**
 
     test.batch.class.names.excludes=\


### PR DESCRIPTION
Found the root cause of (---). Should also close the door for potential collision scenarios with a number of other integration tests in the universe.

See https://github.com/arboliveira/liferay-portal/pull/772/commits/1c03324d18825663cb26a783d09385621c6c30aa for a good laugh. What's this, a one-in-a-trillion chance... twice?

Thanks for being careful with a clearly alarming error and asking for a double check. I wouldn't have it any other way  😃 

----

_[Bug] Search integration tests fail when a randomly chosen keyword contains a number, the substring "to", then another number_
https://issues.liferay.com/browse/LPS-102149
