### PR TITLE
LPS-102311 FIX: (PART 2) Search integration tests fail when a randomly chosen keyword contains a number, the substring "to", then another number

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/CommonSearchResponseAssemblerImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/CommonSearchResponseAssemblerImpl.java
@@ -153,8 +153,10 @@ public class CommonSearchResponseAssemblerImpl
 		baseSearchResponse.setSearchRequestString(
 			StringUtil.removeSubstrings(
 				toString(searchRequestBuilder), ADJUST_PURE_NEGATIVE_STRING,
-				BOOST_STRING, FUZZY_TRANSPOSITIONS_STRING,
-				ZERO_TERMS_QUERY_STRING));
+				AUTO_GENERATE_SYNONYMS_PHRASE_QUERY_STRING, BOOST_STRING,
+				FUZZY_TRANSPOSITIONS_STRING, LENIENT_STRING,
+				MAX_EXPANSIONS_STRING, OPERATOR_STRING, PREFIX_LENGTH_STRING,
+				SLOP_STRING, ZERO_TERMS_QUERY_STRING));
 	}
 
 	protected void setSearchResponseString(
@@ -232,10 +234,27 @@ public class CommonSearchResponseAssemblerImpl
 	protected static final String ADJUST_PURE_NEGATIVE_STRING =
 		",\"adjust_pure_negative\":true";
 
+	protected static final String AUTO_GENERATE_SYNONYMS_PHRASE_QUERY_STRING =
+		",\"auto_generate_synonyms_phrase_query\":true";
+
 	protected static final String BOOST_STRING = ",\"boost\":1.0";
 
 	protected static final String FUZZY_TRANSPOSITIONS_STRING =
 		",\"fuzzy_transpositions\":" + FuzzyQuery.defaultTranspositions;
+
+	protected static final String LENIENT_STRING =
+		",\"lenient\":" + MatchQuery.DEFAULT_LENIENCY;
+
+	protected static final String MAX_EXPANSIONS_STRING =
+		",\"max_expansions\":" + FuzzyQuery.defaultMaxExpansions;
+
+	protected static final String OPERATOR_STRING = ",\"operator\":\"OR\"";
+
+	protected static final String PREFIX_LENGTH_STRING =
+		",\"prefix_length\":" + FuzzyQuery.defaultPrefixLength;
+
+	protected static final String SLOP_STRING =
+		",\"slop\":" + MatchQuery.DEFAULT_PHRASE_SLOP;
 
 	protected static final String ZERO_TERMS_QUERY_STRING =
 		",\"zero_terms_query\":\"" + MatchQuery.DEFAULT_ZERO_TERMS_QUERY + "\"";

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/CommonSearchResponseAssemblerImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/CommonSearchResponseAssemblerImpl.java
@@ -153,8 +153,10 @@ public class CommonSearchResponseAssemblerImpl
 		baseSearchResponse.setSearchRequestString(
 			StringUtil.removeSubstrings(
 				toString(searchRequestBuilder), ADJUST_PURE_NEGATIVE_STRING,
-				BOOST_STRING, FUZZY_TRANSPOSITIONS_STRING,
-				ZERO_TERMS_QUERY_STRING));
+				AUTO_GENERATE_SYNONYMS_PHRASE_QUERY_STRING, BOOST_STRING,
+				FUZZY_TRANSPOSITIONS_STRING, LENIENT_STRING,
+				MAX_EXPANSIONS_STRING, OPERATOR_STRING, PREFIX_LENGTH_STRING,
+				SLOP_STRING, ZERO_TERMS_QUERY_STRING));
 	}
 
 	protected void setSearchResponseString(
@@ -232,10 +234,27 @@ public class CommonSearchResponseAssemblerImpl
 	protected static final String ADJUST_PURE_NEGATIVE_STRING =
 		",\"adjust_pure_negative\":true";
 
+	protected static final String AUTO_GENERATE_SYNONYMS_PHRASE_QUERY_STRING =
+		",\"auto_generate_synonyms_phrase_query\":true";
+
 	protected static final String BOOST_STRING = ",\"boost\":1.0";
 
 	protected static final String FUZZY_TRANSPOSITIONS_STRING =
 		",\"fuzzy_transpositions\":" + FuzzyQuery.defaultTranspositions;
+
+	protected static final String LENIENT_STRING =
+		",\"lenient\":" + MatchQuery.DEFAULT_LENIENCY;
+
+	protected static final String MAX_EXPANSIONS_STRING =
+		",\"max_expansions\":" + FuzzyQuery.defaultMaxExpansions;
+
+	protected static final String OPERATOR_STRING = ",\"operator\":\"OR\"";
+
+	protected static final String PREFIX_LENGTH_STRING =
+		",\"prefix_length\":" + FuzzyQuery.defaultPrefixLength;
+
+	protected static final String SLOP_STRING =
+		",\"slop\":" + MatchQuery.DEFAULT_PHRASE_SLOP;
 
 	protected static final String ZERO_TERMS_QUERY_STRING =
 		",\"zero_terms_query\":\"" + MatchQuery.DEFAULT_ZERO_TERMS_QUERY + "\"";

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FacetsAssert.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FacetsAssert.java
@@ -14,12 +14,16 @@
 
 package com.liferay.portal.search.test.util;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -51,12 +55,29 @@ public class FacetsAssert {
 	}
 
 	public static void assertFrequencies(
+		String facetName, SearchContext searchContext, Hits hits,
+		Map<String, Integer> expected) {
+
+		Map<String, Facet> facets = searchContext.getFacets();
+
+		Facet facet = facets.get(facetName);
+
+		FacetCollector facetCollector = facet.getFacetCollector();
+
+		AssertUtils.assertEquals(
+			StringBundler.concat(
+				searchContext.getAttribute("queryString"), "->",
+				StringUtil.merge(hits.getDocs())),
+			expected,
+			TermCollectorUtil.toMap(facetCollector.getTermCollectors()));
+	}
+
+	public static void assertFrequencies(
 		String facetName, SearchContext searchContext, List<String> expected) {
 
-		String message = (String)searchContext.getAttribute("queryString");
-
 		assertFrequencies(
-			message, searchContext.getFacet(facetName), expected.toString());
+			(String)searchContext.getAttribute("queryString"),
+			searchContext.getFacet(facetName), String.valueOf(expected));
 	}
 
 	protected static String toString(TermCollector termCollector) {

--- a/modules/apps/portal-search/portal-search-test-util/src/main/resources/com/liferay/portal/search/test/util/packageinfo
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/resources/com/liferay/portal/search/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AggregationFilteringTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AggregationFilteringTest.java
@@ -29,12 +29,12 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -44,6 +44,7 @@ import com.liferay.portal.search.facet.site.SiteFacetFactory;
 import com.liferay.portal.search.facet.type.AssetEntriesFacetFactory;
 import com.liferay.portal.search.facet.user.UserFacetFactory;
 import com.liferay.portal.search.test.blogs.util.BlogsEntrySearchFixture;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.search.test.util.SearchMapUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -86,26 +87,12 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 		setUpBlogsEntrySearchFixture();
 		setUpFileEntrySearchFixture();
 
-		_group1 = addGroup();
-		_group2 = addGroup();
+		_group1 = userSearchFixture.addGroup();
+		_group2 = userSearchFixture.addGroup();
 
 		_user1 = addUser();
 		_user2 = addUser();
 		_user3 = addUser();
-
-		_keyword = RandomTestUtil.randomString();
-
-		addBlogsEntry(_group1, _user1, _keyword);
-		addBlogsEntry(_group1, _user2, _keyword);
-		addBlogsEntry(_group2, _user2, _keyword);
-
-		addFileEntry(_group1, _user1, _keyword);
-		addFileEntry(_group2, _user2, _keyword);
-		addFileEntry(_group2, _user3, _keyword);
-
-		addJournalArticle(_group1, _user1, _keyword);
-		addJournalArticle(_group2, _user1, _keyword);
-		addJournalArticle(_group1, _user3, _keyword);
 	}
 
 	@After
@@ -118,7 +105,35 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 	}
 
 	@Test
+	public void testAvoidResidualDataFromDDMStructureLocalServiceTest()
+		throws Exception {
+
+		// See LPS-58543
+
+		String keyword = "To Do";
+
+		index(keyword);
+
+		assertSearch(
+			new Expectations() {
+				{
+					groupFrequencies = SearchMapUtil.join(
+						toMap(_group1, 5), toMap(_group2, 4));
+					typeFrequencies = SearchMapUtil.join(
+						toMap(BlogsEntry.class, 3), toMap(DLFileEntry.class, 3),
+						toMap(JournalArticle.class, 3));
+					userFrequencies = SearchMapUtil.join(
+						toMap(_user1, 4), toMap(_user2, 3), toMap(_user3, 2));
+				}
+			});
+	}
+
+	@Test
 	public void testSelectNone() throws Exception {
+		String keyword = RandomTestUtil.randomString();
+
+		index(keyword);
+
 		assertSearch(
 			new Expectations() {
 				{
@@ -135,6 +150,10 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 
 	@Test
 	public void testSelectOneGroupOneUser() throws Exception {
+		String keyword = RandomTestUtil.randomString();
+
+		index(keyword);
+
 		assertSearch(
 			new Expectations() {
 				{
@@ -152,6 +171,10 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 
 	@Test
 	public void testSelectOneGroupOneUserOneType() throws Exception {
+		String keyword = RandomTestUtil.randomString();
+
+		index(keyword);
+
 		assertSearch(
 			new Expectations() {
 				{
@@ -169,6 +192,10 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 
 	@Test
 	public void testSelectOneUser() throws Exception {
+		String keyword = RandomTestUtil.randomString();
+
+		index(keyword);
+
 		assertSearch(
 			new Expectations() {
 				{
@@ -187,6 +214,10 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 
 	@Test
 	public void testSelectOneUserOneType() throws Exception {
+		String keyword = RandomTestUtil.randomString();
+
+		index(keyword);
+
 		assertSearch(
 			new Expectations() {
 				{
@@ -206,6 +237,10 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 
 	@Test
 	public void testSelectOneUserTwoTypes() throws Exception {
+		String keyword = RandomTestUtil.randomString();
+
+		index(keyword);
+
 		assertSearch(
 			new Expectations() {
 				{
@@ -282,14 +317,6 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 			});
 	}
 
-	protected Group addGroup() throws Exception {
-		Group group = GroupTestUtil.addGroup();
-
-		_groups.add(group);
-
-		return group;
-	}
-
 	protected void addJournalArticle(Group group, User user, String keyword) {
 		journalArticleSearchFixture.addArticle(
 			new JournalArticleBlueprint() {
@@ -335,7 +362,7 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 		searchContext.addFacet(
 			createUserFacet(expectations.selectUsers, searchContext));
 
-		search(searchContext);
+		Hits hits = search(searchContext);
 
 		Set<Map.Entry<Group, Integer>> groupFrequenciesEntrySet =
 			expectations.groupFrequencies.entrySet();
@@ -353,7 +380,8 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 					},
 					Map.Entry::getValue));
 
-		assertFrequencies(Field.GROUP_ID, searchContext, groupFrequencies);
+		FacetsAssert.assertFrequencies(
+			Field.GROUP_ID, searchContext, hits, groupFrequencies);
 
 		Set<Map.Entry<Class<?>, Integer>> typeFrequenciesEntrySet =
 			expectations.typeFrequencies.entrySet();
@@ -371,8 +399,8 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 					},
 					Map.Entry::getValue));
 
-		assertFrequencies(
-			Field.ENTRY_CLASS_NAME, searchContext, typeFrequencies);
+		FacetsAssert.assertFrequencies(
+			Field.ENTRY_CLASS_NAME, searchContext, hits, typeFrequencies);
 
 		Set<Map.Entry<User, Integer>> userFrequenciesEntrySet =
 			expectations.userFrequencies.entrySet();
@@ -390,7 +418,8 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 					},
 					Map.Entry::getValue));
 
-		assertFrequencies(Field.USER_NAME, searchContext, userFrequencies);
+		FacetsAssert.assertFrequencies(
+			Field.USER_NAME, searchContext, hits, userFrequencies);
 	}
 
 	protected Facet createSiteFacet(
@@ -419,6 +448,22 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 		facet.select(getUserFullNames(users));
 
 		return facet;
+	}
+
+	protected void index(String keyword) throws Exception {
+		_keyword = keyword;
+
+		addBlogsEntry(_group1, _user1, keyword);
+		addBlogsEntry(_group1, _user2, keyword);
+		addBlogsEntry(_group2, _user2, keyword);
+
+		addFileEntry(_group1, _user1, keyword);
+		addFileEntry(_group2, _user2, keyword);
+		addFileEntry(_group2, _user3, keyword);
+
+		addJournalArticle(_group1, _user1, keyword);
+		addJournalArticle(_group2, _user1, keyword);
+		addJournalArticle(_group1, _user3, keyword);
 	}
 
 	protected void setUpBlogsEntrySearchFixture() {
@@ -465,10 +510,6 @@ public class AggregationFilteringTest extends BaseFacetedSearcherTestCase {
 	private FileEntrySearchFixture _fileEntrySearchFixture;
 	private Group _group1;
 	private Group _group2;
-
-	@DeleteAfterTestRun
-	private final List<Group> _groups = new ArrayList<>();
-
 	private String _keyword;
 
 	@Inject

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetEntriesFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetEntriesFacetedSearcherTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.facet.Facet;
 import com.liferay.portal.search.facet.type.AssetEntriesFacetFactory;
 import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portlet.documentlibrary.util.test.DLAppTestUtil;
@@ -93,8 +94,8 @@ public class AssetEntriesFacetedSearcherTest
 
 		assertEntryClassNames(_entryClassNames, hits, facet, searchContext);
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext, toMap(_entryClassNames));
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, toMap(_entryClassNames));
 	}
 
 	@Test
@@ -117,8 +118,8 @@ public class AssetEntriesFacetedSearcherTest
 
 		assertEntryClassNames(_entryClassNames, hits, facet, searchContext);
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext, toMap(_entryClassNames));
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, toMap(_entryClassNames));
 	}
 
 	@Test
@@ -141,8 +142,8 @@ public class AssetEntriesFacetedSearcherTest
 			Arrays.asList(JournalArticle.class.getName()), hits, facet,
 			searchContext);
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext, toMap(_entryClassNames));
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, toMap(_entryClassNames));
 	}
 
 	protected static Map<String, Integer> toMap(String key, Integer value) {

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetEntriesStatusFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetEntriesStatusFacetedSearcherTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.facet.type.AssetEntriesFacetFactory;
 import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -72,8 +73,8 @@ public class AssetEntriesStatusFacetedSearcherTest
 
 		assertEntryClassNames(Collections.emptyList(), hits, keyword, facet);
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext, Collections.emptyMap());
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, Collections.emptyMap());
 	}
 
 	@Test
@@ -94,8 +95,8 @@ public class AssetEntriesStatusFacetedSearcherTest
 			Arrays.asList(JournalArticle.class.getName()), hits, keyword,
 			facet);
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext,
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits,
 			Collections.singletonMap(JournalArticle.class.getName(), 1));
 	}
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetEntriesVersionFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetEntriesVersionFacetedSearcherTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.facet.type.AssetEntriesFacetFactory;
 import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -74,8 +75,8 @@ public class AssetEntriesVersionFacetedSearcherTest
 
 		assertVersions(Arrays.asList("1.0"), hits, keyword);
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext,
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits,
 			Collections.singletonMap(JournalArticle.class.getName(), 1));
 	}
 
@@ -99,8 +100,8 @@ public class AssetEntriesVersionFacetedSearcherTest
 
 		assertVersions(Arrays.asList("1.1"), hits, keyword);
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext,
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits,
 			Collections.singletonMap(JournalArticle.class.getName(), 1));
 	}
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetTagNamesFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetTagNamesFacetedSearcherTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.facet.Facet;
 import com.liferay.portal.search.facet.tag.AssetTagNamesFacetFactory;
 import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -85,7 +86,8 @@ public class AssetTagNamesFacetedSearcherTest
 		Map<String, Integer> frequencies = Collections.singletonMap(
 			StringUtil.toLowerCase(tag), 1);
 
-		assertFrequencies(facet.getFieldName(), searchContext, frequencies);
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
 	}
 
 	@Test
@@ -100,11 +102,12 @@ public class AssetTagNamesFacetedSearcherTest
 
 		searchContext.addFacet(facet);
 
-		search(searchContext);
+		Hits hits = search(searchContext);
 
 		Map<String, Integer> frequencies = Collections.singletonMap(tag, 1);
 
-		assertFrequencies(facet.getFieldName(), searchContext, frequencies);
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
 	}
 
 	@Test
@@ -154,7 +157,8 @@ public class AssetTagNamesFacetedSearcherTest
 		Map<String, Integer> frequencies = Collections.singletonMap(
 			tagToLowerCase, 1);
 
-		assertFrequencies(facet.getFieldName(), searchContext, frequencies);
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
 	}
 
 	protected void addJournalArticle(Group group, String title)

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/BaseFacetedSearcherTestCase.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/BaseFacetedSearcherTestCase.java
@@ -18,22 +18,17 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.search.JournalArticleSearchFixture;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.search.facet.Facet;
-import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcher;
 import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcherManager;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
 import com.liferay.portal.search.test.util.AssertUtils;
-import com.liferay.portal.search.test.util.TermCollectorUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
 
@@ -99,41 +94,6 @@ public abstract class BaseFacetedSearcherTestCase {
 			(String)searchContext.getAttribute("queryString") + "->" +
 				documents.toString(),
 			documents.isEmpty());
-	}
-
-	protected void assertFrequencies(
-		String fieldName, SearchContext searchContext, Hits hits,
-		Map<String, Integer> expected) {
-
-		assertFrequencies(
-			fieldName, searchContext, expected,
-			StringBundler.concat(
-				searchContext.getAttribute("queryString"), "->",
-				StringUtil.merge(hits.getDocs())));
-	}
-
-	protected void assertFrequencies(
-		String fieldName, SearchContext searchContext,
-		Map<String, Integer> expected) {
-
-		assertFrequencies(
-			fieldName, searchContext, expected,
-			(String)searchContext.getAttribute("queryString"));
-	}
-
-	protected void assertFrequencies(
-		String fieldName, SearchContext searchContext,
-		Map<String, Integer> expected, String message) {
-
-		Map<String, Facet> facets = searchContext.getFacets();
-
-		Facet facet = facets.get(fieldName);
-
-		FacetCollector facetCollector = facet.getFacetCollector();
-
-		AssertUtils.assertEquals(
-			message, expected,
-			TermCollectorUtil.toMap(facetCollector.getTermCollectors()));
 	}
 
 	protected void assertTags(

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/CalendarFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/CalendarFacetedSearcherTest.java
@@ -26,6 +26,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.MultiValueFacet;
@@ -39,6 +40,7 @@ import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -110,10 +112,10 @@ public class CalendarFacetedSearcherTest extends BaseFacetedSearcherTestCase {
 
 		searchContext.addFacet(facet);
 
-		search(searchContext);
+		Hits hits = search(searchContext);
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext,
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits,
 			Collections.singletonMap(
 				StringUtil.toLowerCase(user2.getFullName()), 1));
 	}

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/CategoryFacetTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/CategoryFacetTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.search.facet.category.CategoryFacetFactory;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -97,7 +98,7 @@ public class CategoryFacetTest extends BaseFacetedSearcherTestCase {
 		Map<String, Integer> frequencies = Collections.singletonMap(
 			String.valueOf(categoryId), 1);
 
-		assertFrequencies(
+		FacetsAssert.assertFrequencies(
 			facet.getFieldName(), searchContext, hits, frequencies);
 	}
 
@@ -130,7 +131,7 @@ public class CategoryFacetTest extends BaseFacetedSearcherTestCase {
 		Map<String, Integer> frequencies = Collections.singletonMap(
 			String.valueOf(categoryId), 1);
 
-		assertFrequencies(
+		FacetsAssert.assertFrequencies(
 			facet.getFieldName(), searchContext, hits, frequencies);
 	}
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.search.facet.Facet;
 import com.liferay.portal.search.facet.custom.CustomFacetFactory;
 import com.liferay.portal.search.facet.folder.FolderFacetFactory;
 import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portlet.documentlibrary.util.test.DLAppTestUtil;
@@ -114,8 +115,8 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 		List<String> dlFolderIds = Arrays.asList(
 			ArrayUtil.append(getFolderIds(_dlFolders), "0"));
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext, toMap(dlFolderIds, 1));
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, toMap(dlFolderIds, 1));
 	}
 
 	@Test
@@ -147,8 +148,8 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 		List<String> dlFolderIds = Arrays.asList(
 			ArrayUtil.append(getFolderIds(_dlFolders), "0"));
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext, toMap(dlFolderIds, 1));
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, toMap(dlFolderIds, 1));
 	}
 
 	@Test
@@ -176,8 +177,8 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 		List<String> dlFolderIds = Arrays.asList(
 			ArrayUtil.append(getFolderIds(_dlFolders), "0"));
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext, toMap(dlFolderIds, 1));
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, toMap(dlFolderIds, 1));
 	}
 
 	@Test
@@ -208,8 +209,8 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 		List<String> dlFolderIds = Arrays.asList(
 			ArrayUtil.append(getFolderIds(_dlFolders), StringPool.BLANK));
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext, toMap(dlFolderIds, 2));
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, toMap(dlFolderIds, 2));
 	}
 
 	protected void assertEntryClassNames(

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ModifiedFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ModifiedFacetedSearcherTest.java
@@ -20,12 +20,14 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.facet.modified.ModifiedFacetFactory;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.search.test.util.SearchMapUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -71,13 +73,14 @@ public class ModifiedFacetedSearcherTest extends BaseFacetedSearcherTestCase {
 
 		searchContext.addFacet(facet);
 
-		search(searchContext);
+		Hits hits = search(searchContext);
 
 		Map<String, Integer> frequencies = SearchMapUtil.join(
 			toMap(configRange1, 0), toMap(configRange2, 1),
 			toMap(customRange, 1));
 
-		assertFrequencies(facet.getFieldName(), searchContext, frequencies);
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
 	}
 
 	protected static JSONObject createDataJSONObject(String... ranges) {

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/PermissionFilterFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/PermissionFilterFacetedSearcherTest.java
@@ -25,6 +25,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -40,6 +41,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.facet.type.AssetEntriesFacetFactory;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -117,12 +119,13 @@ public class PermissionFilterFacetedSearcherTest
 
 		searchContext.addFacet(facet);
 
-		search(searchContext);
+		Hits hits = search(searchContext);
 
 		Map<String, Integer> expected = Collections.singletonMap(
 			JournalArticle.class.getName(), 1);
 
-		assertFrequencies(facet.getFieldName(), searchContext, expected);
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, expected);
 	}
 
 	protected void addJournalArticle(

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ScopeFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ScopeFacetedSearcherTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.facet.site.SiteFacetFactory;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.search.test.util.SearchMapUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -68,12 +69,13 @@ public class ScopeFacetedSearcherTest extends BaseFacetedSearcherTestCase {
 
 		searchContext.addFacet(facet);
 
-		search(searchContext);
+		Hits hits = search(searchContext);
 
 		Map<String, Integer> frequencies = SearchMapUtil.join(
 			toMap(group1, 1), toMap(group2, 2));
 
-		assertFrequencies(facet.getFieldName(), searchContext, frequencies);
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
 	}
 
 	@Test
@@ -105,7 +107,8 @@ public class ScopeFacetedSearcherTest extends BaseFacetedSearcherTestCase {
 		Map<String, Integer> frequencies = SearchMapUtil.join(
 			toMap(group1, 1), toMap(group2, 1));
 
-		assertFrequencies(facet.getFieldName(), searchContext, frequencies);
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
 
 		Map<String, String> tags = SearchMapUtil.join(
 			toMap(user1, tag1), toMap(user2, tag2));
@@ -143,7 +146,8 @@ public class ScopeFacetedSearcherTest extends BaseFacetedSearcherTestCase {
 
 		Map<String, Integer> frequencies = toMap(group1, 1);
 
-		assertFrequencies(facet.getFieldName(), searchContext, frequencies);
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
 
 		Map<String, String> tags = toMap(user1, tag1);
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/SearchPermissionCheckerFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/SearchPermissionCheckerFacetedSearcherTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.MultiValueFacet;
@@ -36,6 +37,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -108,10 +110,10 @@ public class SearchPermissionCheckerFacetedSearcherTest
 
 		searchContext.addFacet(facet);
 
-		search(searchContext);
+		Hits hits = search(searchContext);
 
-		assertFrequencies(
-			facet.getFieldName(), searchContext,
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits,
 			Collections.singletonMap(
 				StringUtil.toLowerCase(user2.getFullName()), 1));
 	}

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/UserFacetedSearcherTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/UserFacetedSearcherTest.java
@@ -21,6 +21,7 @@ import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.MultiValueFacet;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.test.util.FacetsAssert;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.users.admin.test.util.search.DummyPermissionChecker;
@@ -82,12 +84,13 @@ public class UserFacetedSearcherTest extends BaseFacetedSearcherTestCase {
 
 		setUpPermissionChecker(group.getCompanyId());
 
-		search(searchContext);
+		Hits hits = search(searchContext);
 
 		Map<String, Integer> frequencies = Collections.singletonMap(
 			StringUtil.toLowerCase(user.getFullName()), 2);
 
-		assertFrequencies(facet.getFieldName(), searchContext, frequencies);
+		FacetsAssert.assertFrequencies(
+			facet.getFieldName(), searchContext, hits, frequencies);
 	}
 
 	protected void addJournalArticle(User user, Group group, String title)


### PR DESCRIPTION
Second and final part, hopefully; QA spotted the original random failure in one last test and I double checked all the others.

----

_[Bug] Search integration tests fail when a randomly chosen keyword contains a number, the substring "to", then another number (Part 2)_
https://issues.liferay.com/browse/LPS-102311