### PR TITLE
LPS-107538 New Indexer Architecture silently aborts full reindex in case an Exception is thrown inside _indexerDocumentBuilder.getDocument method

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -201,7 +201,13 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 							}
 							catch (Exception exception) {
 								if (_log.isWarnEnabled()) {
-									_log.warn(exception, exception);
+									_log.warn(
+										StringBundler.concat(
+											"Error indexing ",
+											_modelSearchSettings.getClassName(),
+											" with primaryKey=",
+											baseModel.getPrimaryKeyObj()),
+										exception);
 								}
 
 								return null;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -195,8 +195,17 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 
 						@Override
 						public Document getDocument(BaseModel baseModel) {
-							return _indexerDocumentBuilder.getDocument(
-								baseModel);
+							try {
+								return _indexerDocumentBuilder.getDocument(
+									baseModel);
+							}
+							catch (Exception exception) {
+								if (_log.isWarnEnabled()) {
+									_log.warn(exception, exception);
+								}
+
+								return null;
+							}
 						}
 
 					});

--- a/modules/apps/portal-search/portal-search/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/portal-search/portal-search/src/main/resources/META-INF/module-log4j.xml
@@ -5,4 +5,8 @@
 	<category name="com.liferay.portal.search.internal.IndexerRegistryImpl">
 		<priority value="WARN" />
 	</category>
+
+	<category name="com.liferay.portal.search.internal.indexer.IndexerWriterImpl">
+		<priority value="WARN" />
+	</category>
 </log4j:configuration>


### PR DESCRIPTION
See full description in https://issues.liferay.com/browse/LPS-107538

/cc: @lipusz