### PR TITLE
LPS-111371 Navigating to Business Accounts and Account Users portlet would sometimes result to temporarily unavailable

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/searcher/UserSearchRequestBuilder.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/searcher/UserSearchRequestBuilder.java
@@ -17,16 +17,14 @@ package com.liferay.account.internal.search.searcher;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.searcher.SearchRequest;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
-import com.liferay.portal.search.sort.FieldSort;
 import com.liferay.portal.search.sort.SortFieldBuilder;
-import com.liferay.portal.search.sort.SortOrder;
-import com.liferay.portal.search.sort.Sorts;
 
 import java.io.Serializable;
 
@@ -68,21 +66,6 @@ public class UserSearchRequestBuilder {
 		if (_cur != QueryUtil.ALL_POS) {
 			searchRequestBuilder.from(_cur);
 			searchRequestBuilder.size(_delta);
-		}
-
-		if (Validator.isNotNull(_sortField)) {
-			SortOrder sortOrder = SortOrder.ASC;
-
-			if (_reverse) {
-				sortOrder = SortOrder.DESC;
-			}
-
-			FieldSort fieldSort = _sorts.field(
-				_sortFieldBuilder.getSortField(
-					User.class.getName(), _sortField),
-				sortOrder);
-
-			searchRequestBuilder.sorts(fieldSort);
 		}
 
 		return searchRequestBuilder.build();
@@ -170,6 +153,14 @@ public class UserSearchRequestBuilder {
 		searchContext.setAttributes(attributes);
 
 		searchContext.setCompanyId(CompanyThreadLocal.getCompanyId());
+
+		if (Validator.isNotNull(_sortField)) {
+			searchContext.setSorts(
+				new Sort(
+					_sortFieldBuilder.getSortField(
+						User.class.getName(), _sortField),
+					_reverse));
+		}
 	}
 
 	private Map<String, Serializable> _attributes = new HashMap<>();
@@ -185,9 +176,6 @@ public class UserSearchRequestBuilder {
 
 	@Reference
 	private SortFieldBuilder _sortFieldBuilder;
-
-	@Reference
-	private Sorts _sorts;
 
 	private int _status;
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -50,9 +51,7 @@ import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
-import com.liferay.portal.search.sort.FieldSort;
 import com.liferay.portal.search.sort.SortFieldBuilder;
-import com.liferay.portal.search.sort.SortOrder;
 import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.users.admin.kernel.file.uploads.UserFileUploadsSettings;
@@ -336,27 +335,13 @@ public class AccountEntryLocalServiceImpl
 			false
 		).withSearchContext(
 			searchContext -> _populateSearchContext(
-				searchContext, companyId, keywords, params)
+				searchContext, companyId, keywords, params, orderByField,
+				reverse)
 		);
 
 		if (cur != QueryUtil.ALL_POS) {
 			searchRequestBuilder.from(cur);
 			searchRequestBuilder.size(delta);
-		}
-
-		if (Validator.isNotNull(orderByField)) {
-			SortOrder sortOrder = SortOrder.ASC;
-
-			if (reverse) {
-				sortOrder = SortOrder.DESC;
-			}
-
-			FieldSort fieldSort = _sorts.field(
-				_sortFieldBuilder.getSortField(
-					AccountEntry.class.getName(), orderByField),
-				sortOrder);
-
-			searchRequestBuilder.sorts(fieldSort);
 		}
 
 		return searchRequestBuilder.build();
@@ -382,12 +367,21 @@ public class AccountEntryLocalServiceImpl
 
 	private void _populateSearchContext(
 		SearchContext searchContext, long companyId, String keywords,
-		LinkedHashMap<String, Object> params) {
+		LinkedHashMap<String, Object> params, String orderbyField,
+		boolean reverse) {
 
 		searchContext.setCompanyId(companyId);
 
 		if (Validator.isNotNull(keywords)) {
 			searchContext.setKeywords(keywords);
+		}
+
+		if (Validator.isNotNull(orderbyField)) {
+			searchContext.setSorts(
+				new Sort(
+					_sortFieldBuilder.getSortField(
+						AccountEntry.class.getName(), orderbyField),
+					reverse));
 		}
 
 		if (MapUtil.isEmpty(params)) {

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5861,6 +5861,7 @@
     # Env: LIFERAY_INDEX_PERIOD_SORTABLE_PERIOD_TEXT_PERIOD_FIELDS
     #
     index.sortable.text.fields=\
+        emailAddress,\
         firstName,\
         jobTitle,\
         lastName,\


### PR DESCRIPTION
Hi Andre,

This issue is similar to [LPS-102020](https://issues.liferay.com/browse/LPS-101020). The exception only occurs on a clean bundle when there's no mapping for the specified sort fields yet. When starting up a clean bundle, the search field mappings only include the fields in . Additional mappings (lastName, lastName_sortable, firstName, firstName_sortable, etc.) are not added until a document is created (in our case, after a new user is added).

In the Account Users portlet we have the following sort fields: firstName, lastName, and emailAddress, which are not included in the liferay-type-mappings.json file.

Looking at the [search request sort](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-sort.html#_ignoring_unmapped_fields) on elasticsearch, the option is to use the  to ignore the unmapped field. However, it seems we don't support that in our search framework. There's no simple way to set the unmapped_type on com.liferay.portal.search.sort.Sort. The only usage I found with the unmapped_type is in the , which is only being used for the legacy sort in portal-kernel.

What do you think is the best practice for cases like this? Should we use the legacy sort or add the missing field mappings in liferay-type-mappings.json? Thanks.

/cc @drewbrokke @alee888