### PR TITLE
[TS] LPS-110846 Many Inactive Groups (Sites or deactivated Users) causes User Groups and Users and Organizations pages to load slowly or fail to load

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.filter.groupid;
+
+import com.liferay.portal.search.elasticsearch6.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.filter.groupid.BaseGroupIdQueryPreFilterContributorTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author Tibor Lipusz
+ */
+public class GroupIdQueryPreFilterContributorTest
+	extends BaseGroupIdQueryPreFilterContributorTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/filter/groupid/GroupIdQueryPreFilterContributorTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.filter.groupid;
+
+import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.filter.groupid.BaseGroupIdQueryPreFilterContributorTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author Tibor Lipusz
+ */
+public class GroupIdQueryPreFilterContributorTest
+	extends BaseGroupIdQueryPreFilterContributorTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.filter.groupid;
+
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.search.internal.spi.model.query.contributor.GroupIdQueryPreFilterContributor;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Tibor Lipusz
+ * @author André de Oliveira
+ */
+public abstract class BaseGroupIdQueryPreFilterContributorTestCase
+	extends BaseIndexingTestCase {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		MockitoAnnotations.initMocks(this);
+
+		Mockito.doReturn(
+			Arrays.asList(INACTIVE_GROUP_ID1, INACTIVE_GROUP_ID2)
+		).when(
+			groupLocalService
+		).getActiveGroupIds(
+			Mockito.anyLong(), Mockito.eq(false)
+		);
+	}
+
+	@Test
+	public void testScopeEverythingWithInactiveGroups() {
+		addDocuments(1, 2, 3, INACTIVE_GROUP_ID1, INACTIVE_GROUP_ID2);
+
+		assertSearch(0, "[1, 2, 3]");
+
+		Mockito.verify(
+			groupLocalService, Mockito.never()
+		).getActiveGroups(
+			Mockito.anyLong(), Mockito.anyBoolean()
+		);
+	}
+
+	@Test
+	public void testScopeSingleGroup() throws Exception {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.doReturn(
+			group
+		).when(
+			groupLocalService
+		).getGroup(
+			2
+		);
+
+		Mockito.doReturn(
+			true
+		).when(
+			groupLocalService
+		).isLiveGroupActive(
+			group
+		);
+
+		addDocuments(1, 2, 3, INACTIVE_GROUP_ID1, INACTIVE_GROUP_ID2);
+
+		assertSearch(2, "[2]");
+	}
+
+	protected void addDocuments(long... groupIds) {
+		for (long groupId : groupIds) {
+			addDocument(
+				document -> {
+					document.addKeyword(Field.GROUP_ID, groupId);
+					document.addKeyword(Field.SCOPE_GROUP_ID, groupId);
+				});
+		}
+	}
+
+	protected void assertSearch(long scopeGroupId, String expected) {
+		assertSearch(
+			indexingTestHelper -> {
+				indexingTestHelper.define(
+					searchContext -> {
+						searchContext.setGroupIds(new long[] {scopeGroupId});
+
+						indexingTestHelper.setFilter(
+							createFilter(searchContext));
+					});
+
+				indexingTestHelper.search();
+
+				indexingTestHelper.verifyResponse(
+					searchResponse ->
+						DocumentsAssert.assertValuesIgnoreRelevance(
+							searchResponse.getRequestString(),
+							searchResponse.getDocumentsStream(), Field.GROUP_ID,
+							expected));
+			});
+	}
+
+	protected Filter createFilter(SearchContext searchContext) {
+		GroupIdQueryPreFilterContributor contributor =
+			new GroupIdQueryPreFilterContributor();
+
+		contributor.setGroupLocalService(groupLocalService);
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		contributor.contribute(booleanFilter, searchContext);
+
+		return booleanFilter;
+	}
+
+	protected static final long INACTIVE_GROUP_ID1 = 4L;
+
+	protected static final long INACTIVE_GROUP_ID2 = 5L;
+
+	@Mock
+	protected GroupLocalService groupLocalService;
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
@@ -70,7 +70,7 @@ public class GroupIdQueryPreFilterContributor
 
 			Group group = _getGroup(groupId);
 
-			if (!groupLocalService.isLiveGroupActive(group)) {
+			if (!_groupLocalService.isLiveGroupActive(group)) {
 				continue;
 			}
 
@@ -102,13 +102,15 @@ public class GroupIdQueryPreFilterContributor
 		booleanFilter.add(scopeBooleanFilter, BooleanClauseOccur.MUST);
 	}
 
-	@Reference
-	protected GroupLocalService groupLocalService;
+	@Reference(unbind = "-")
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		_groupLocalService = groupLocalService;
+	}
 
 	private void _addInactiveGroupsBooleanFilter(
 		BooleanFilter booleanFilter, SearchContext searchContext) {
 
-		List<Long> inactiveGroupIds = groupLocalService.getActiveGroupIds(
+		List<Long> inactiveGroupIds = _groupLocalService.getActiveGroupIds(
 			searchContext.getCompanyId(), false);
 
 		if (ListUtil.isEmpty(inactiveGroupIds)) {
@@ -135,11 +137,13 @@ public class GroupIdQueryPreFilterContributor
 
 	private Group _getGroup(long groupId) {
 		try {
-			return groupLocalService.getGroup(groupId);
+			return _groupLocalService.getGroup(groupId);
 		}
 		catch (PortalException portalException) {
 			throw new SystemException(portalException);
 		}
 	}
+
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/GroupIdQueryPreFilterContributor.java
@@ -108,18 +108,17 @@ public class GroupIdQueryPreFilterContributor
 	private void _addInactiveGroupsBooleanFilter(
 		BooleanFilter booleanFilter, SearchContext searchContext) {
 
-		List<Group> inactiveGroups = groupLocalService.getActiveGroups(
+		List<Long> inactiveGroupIds = groupLocalService.getActiveGroupIds(
 			searchContext.getCompanyId(), false);
 
-		if (ListUtil.isEmpty(inactiveGroups)) {
+		if (ListUtil.isEmpty(inactiveGroupIds)) {
 			return;
 		}
 
 		TermsFilter groupIdTermsFilter = new TermsFilter(Field.GROUP_ID);
 
 		groupIdTermsFilter.addValues(
-			ArrayUtil.toStringArray(
-				ListUtil.toArray(inactiveGroups, Group.GROUP_ID_ACCESSOR)));
+			ArrayUtil.toStringArray(inactiveGroupIds.toArray(new Long[0])));
 
 		booleanFilter.add(groupIdTermsFilter, BooleanClauseOccur.MUST_NOT);
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -1415,6 +1415,11 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		return groupFinder.findByActiveGroupIds(userId);
 	}
 
+	@Override
+	public List<Long> getActiveGroupIds(long companyId, boolean active) {
+		return groupFinder.findByActiveGroupIds(companyId, active);
+	}
+
 	/**
 	 * Returns all the active or inactive groups associated with the company.
 	 *

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -73,6 +73,9 @@ public class GroupFinderImpl
 	public static final String FIND_BY_ACTIVE_GROUPS =
 		GroupFinder.class.getName() + ".findByActiveGroups";
 
+	public static final String FIND_BY_ACTIVE_GROUP_IDS =
+		GroupFinder.class.getName() + ".findByActiveGroupIds";
+
 	public static final String FIND_BY_COMPANY_ID =
 		GroupFinder.class.getName() + ".findByCompanyId";
 
@@ -354,6 +357,34 @@ public class GroupFinderImpl
 			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
 
 			queryPos.add(userId);
+
+			return sqlQuery.list(true);
+		}
+		catch (Exception exception) {
+			throw new SystemException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	@Override
+	public List<Long> findByActiveGroupIds(long companyId, boolean active) {
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = CustomSQLUtil.get(FIND_BY_ACTIVE_GROUP_IDS);
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar("groupId", Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(companyId);
+			queryPos.add(active);
 
 			return sqlQuery.list(true);
 		}

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -63,6 +63,17 @@
 				(Group_.active_ = [$TRUE$])
 		]]>
 	</sql>
+	<sql id="com.liferay.portal.kernel.service.persistence.GroupFinder.findByActiveGroupIds">
+		<![CDATA[
+			SELECT
+				Group_.groupId
+			FROM
+				Group_
+			WHERE
+				(Group_.companyId = ?) AND
+				(Group_.active_ = ?)
+		]]>
+	</sql>
 	<sql id="com.liferay.portal.kernel.service.persistence.GroupFinder.findByCompanyId">
 		<![CDATA[
 			SELECT

--- a/portal-kernel/src/com/liferay/portal/kernel/service/GroupLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/GroupLocalService.java
@@ -376,6 +376,9 @@ public interface GroupLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Long> getActiveGroupIds(long userId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Long> getActiveGroupIds(long companyId, boolean active);
+
 	/**
 	 * Returns all the active or inactive groups associated with the company.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/GroupLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/GroupLocalServiceUtil.java
@@ -566,6 +566,12 @@ public class GroupLocalServiceUtil {
 		return getService().getActiveGroupIds(userId);
 	}
 
+	public static java.util.List<Long> getActiveGroupIds(
+		long companyId, boolean active) {
+
+		return getService().getActiveGroupIds(companyId, active);
+	}
+
 	/**
 	 * Returns all the active or inactive groups associated with the company.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/GroupLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/GroupLocalServiceWrapper.java
@@ -610,6 +610,13 @@ public class GroupLocalServiceWrapper
 		return _groupLocalService.getActiveGroupIds(userId);
 	}
 
+	@Override
+	public java.util.List<java.lang.Long> getActiveGroupIds(
+		long companyId, boolean active) {
+
+		return _groupLocalService.getActiveGroupIds(companyId, active);
+	}
+
 	/**
 	 * Returns all the active or inactive groups associated with the company.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/GroupFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/GroupFinder.java
@@ -37,6 +37,9 @@ public interface GroupFinder {
 
 	public java.util.List<Long> findByActiveGroupIds(long userId);
 
+	public java.util.List<Long> findByActiveGroupIds(
+		long companyId, boolean active);
+
 	public java.util.List<com.liferay.portal.kernel.model.Group>
 		findByCompanyId(
 			long companyId, java.util.LinkedHashMap<String, Object> params,

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/GroupFinderUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/GroupFinderUtil.java
@@ -53,6 +53,12 @@ public class GroupFinderUtil {
 		return getFinder().findByActiveGroupIds(userId);
 	}
 
+	public static java.util.List<Long> findByActiveGroupIds(
+		long companyId, boolean active) {
+
+		return getFinder().findByActiveGroupIds(companyId, active);
+	}
+
 	public static java.util.List<com.liferay.portal.kernel.model.Group>
 		findByCompanyId(
 			long companyId, java.util.LinkedHashMap<String, Object> params,

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0


### PR DESCRIPTION
cc/ @lipusz

https://issues.liferay.com/browse/LPS-110846