### PR TITLE
LPS-112287 FIX: Sort in SearchRequestBuilder fails on empty Elasticsearch index: "No mapping found for [field] in order to sort on" + LPS-112322 DEFLAKE: MoreLikeThisQueryTest

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/sort/ElasticsearchSortFieldTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/sort/ElasticsearchSortFieldTranslator.java
@@ -85,7 +85,7 @@ public class ElasticsearchSortFieldTranslator
 			fieldSortBuilder.sortMode(translate(sortMode));
 		}
 
-		return fieldSortBuilder;
+		return fieldSortBuilder.unmappedType("keyword");
 	}
 
 	@Override

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/SearchRequestExecutorFixture.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/search/SearchRequestExecutorFixture.java
@@ -35,8 +35,10 @@ import com.liferay.portal.search.elasticsearch6.internal.stats.DefaultStatsTrans
 import com.liferay.portal.search.elasticsearch6.internal.stats.StatsTranslator;
 import com.liferay.portal.search.elasticsearch6.internal.suggest.ElasticsearchSuggesterTranslatorFixture;
 import com.liferay.portal.search.engine.adapter.search.SearchRequestExecutor;
+import com.liferay.portal.search.filter.ComplexQueryBuilderFactory;
 import com.liferay.portal.search.internal.aggregation.AggregationResultsImpl;
 import com.liferay.portal.search.internal.document.DocumentBuilderFactoryImpl;
+import com.liferay.portal.search.internal.filter.ComplexQueryBuilderFactoryImpl;
 import com.liferay.portal.search.internal.geolocation.GeoBuildersImpl;
 import com.liferay.portal.search.internal.groupby.GroupByResponseFactoryImpl;
 import com.liferay.portal.search.internal.highlight.HighlightFieldBuilderFactoryImpl;
@@ -45,8 +47,10 @@ import com.liferay.portal.search.internal.hits.SearchHitsBuilderFactoryImpl;
 import com.liferay.portal.search.internal.legacy.groupby.GroupByRequestFactoryImpl;
 import com.liferay.portal.search.internal.legacy.stats.StatsRequestBuilderFactoryImpl;
 import com.liferay.portal.search.internal.legacy.stats.StatsResultsTranslatorImpl;
+import com.liferay.portal.search.internal.query.QueriesImpl;
 import com.liferay.portal.search.internal.stats.StatsResponseBuilderFactoryImpl;
 import com.liferay.portal.search.legacy.stats.StatsRequestBuilderFactory;
+import com.liferay.portal.search.query.Queries;
 
 /**
  * @author Michael C. Han
@@ -84,13 +88,15 @@ public class SearchRequestExecutorFixture {
 						new StatsResponseBuilderFactoryImpl());
 				}
 			},
-			new StatsRequestBuilderFactoryImpl());
+			new StatsRequestBuilderFactoryImpl(),
+			createComplexQueryBuilderFactory(new QueriesImpl()));
 	}
 
 	protected static CommonSearchRequestBuilderAssembler
 		createCommonSearchRequestBuilderAssembler(
 			ElasticsearchQueryTranslator elasticsearchQueryTranslator,
-			FacetProcessor facetProcessor, StatsTranslator statsTranslator) {
+			FacetProcessor facetProcessor, StatsTranslator statsTranslator,
+			ComplexQueryBuilderFactory complexQueryBuilderFactory) {
 
 		ElasticsearchAggregationVisitorFixture
 			elasticsearchAggregationVisitorFixture =
@@ -121,6 +127,8 @@ public class SearchRequestExecutorFixture {
 					elasticsearchAggregationVisitorFixture.
 						getElasticsearchAggregationVisitor());
 
+				setComplexQueryBuilderFactory(complexQueryBuilderFactory);
+
 				setFacetTranslator(createFacetTranslator(facetProcessor));
 
 				setFilterToQueryBuilderTranslator(
@@ -137,6 +145,16 @@ public class SearchRequestExecutorFixture {
 				setQueryToQueryBuilderTranslator(elasticsearchQueryTranslator);
 
 				setStatsTranslator(statsTranslator);
+			}
+		};
+	}
+
+	protected static ComplexQueryBuilderFactory
+		createComplexQueryBuilderFactory(Queries queries) {
+
+		return new ComplexQueryBuilderFactoryImpl() {
+			{
+				setQueries(queries);
 			}
 		};
 	}
@@ -201,13 +219,14 @@ public class SearchRequestExecutorFixture {
 		ElasticsearchQueryTranslator elasticsearchQueryTranslator,
 		ElasticsearchSortFieldTranslator elasticsearchSortFieldTranslator,
 		FacetProcessor facetProcessor, StatsTranslator statsTranslator,
-		StatsRequestBuilderFactory statsRequestBuilderFactory) {
+		StatsRequestBuilderFactory statsRequestBuilderFactory,
+		ComplexQueryBuilderFactory complexQueryBuilderFactory) {
 
 		CommonSearchRequestBuilderAssembler
 			commonSearchRequestBuilderAssembler =
 				createCommonSearchRequestBuilderAssembler(
 					elasticsearchQueryTranslator, facetProcessor,
-					statsTranslator);
+					statsTranslator, complexQueryBuilderFactory);
 
 		SearchSearchRequestAssembler searchSearchRequestAssembler =
 			createSearchSearchRequestAssembler(

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/sort/ElasticsearchSortUnmappedFieldsTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/sort/ElasticsearchSortUnmappedFieldsTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.sort;
+
+import com.liferay.portal.search.elasticsearch6.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.sort.BaseSortUnmappedFieldsTestCase;
+
+/**
+ * @author André de Oliveira
+ */
+public class ElasticsearchSortUnmappedFieldsTest
+	extends BaseSortUnmappedFieldsTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchSortFieldTranslator.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchSortFieldTranslator.java
@@ -85,7 +85,7 @@ public class ElasticsearchSortFieldTranslator
 			fieldSortBuilder.sortMode(translate(sortMode));
 		}
 
-		return fieldSortBuilder;
+		return fieldSortBuilder.unmappedType("keyword");
 	}
 
 	@Override

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/SearchRequestExecutorFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/search/SearchRequestExecutorFixture.java
@@ -35,8 +35,10 @@ import com.liferay.portal.search.elasticsearch7.internal.stats.DefaultStatsTrans
 import com.liferay.portal.search.elasticsearch7.internal.stats.StatsTranslator;
 import com.liferay.portal.search.elasticsearch7.internal.suggest.ElasticsearchSuggesterTranslatorFixture;
 import com.liferay.portal.search.engine.adapter.search.SearchRequestExecutor;
+import com.liferay.portal.search.filter.ComplexQueryBuilderFactory;
 import com.liferay.portal.search.internal.aggregation.AggregationResultsImpl;
 import com.liferay.portal.search.internal.document.DocumentBuilderFactoryImpl;
+import com.liferay.portal.search.internal.filter.ComplexQueryBuilderFactoryImpl;
 import com.liferay.portal.search.internal.geolocation.GeoBuildersImpl;
 import com.liferay.portal.search.internal.groupby.GroupByResponseFactoryImpl;
 import com.liferay.portal.search.internal.highlight.HighlightFieldBuilderFactoryImpl;
@@ -45,8 +47,10 @@ import com.liferay.portal.search.internal.hits.SearchHitsBuilderFactoryImpl;
 import com.liferay.portal.search.internal.legacy.groupby.GroupByRequestFactoryImpl;
 import com.liferay.portal.search.internal.legacy.stats.StatsRequestBuilderFactoryImpl;
 import com.liferay.portal.search.internal.legacy.stats.StatsResultsTranslatorImpl;
+import com.liferay.portal.search.internal.query.QueriesImpl;
 import com.liferay.portal.search.internal.stats.StatsResponseBuilderFactoryImpl;
 import com.liferay.portal.search.legacy.stats.StatsRequestBuilderFactory;
+import com.liferay.portal.search.query.Queries;
 
 /**
  * @author Michael C. Han
@@ -84,13 +88,15 @@ public class SearchRequestExecutorFixture {
 						new StatsResponseBuilderFactoryImpl());
 				}
 			},
-			new StatsRequestBuilderFactoryImpl());
+			new StatsRequestBuilderFactoryImpl(),
+			createComplexQueryBuilderFactory(new QueriesImpl()));
 	}
 
 	protected static CommonSearchSourceBuilderAssembler
 		createCommonSearchSourceBuilderAssembler(
 			ElasticsearchQueryTranslator elasticsearchQueryTranslator,
-			FacetProcessor facetProcessor, StatsTranslator statsTranslator) {
+			FacetProcessor facetProcessor, StatsTranslator statsTranslator,
+			ComplexQueryBuilderFactory complexQueryBuilderFactory) {
 
 		ElasticsearchAggregationVisitorFixture
 			elasticsearchAggregationVisitorFixture =
@@ -121,6 +127,8 @@ public class SearchRequestExecutorFixture {
 					elasticsearchAggregationVisitorFixture.
 						getElasticsearchAggregationVisitor());
 
+				setComplexQueryBuilderFactory(complexQueryBuilderFactory);
+
 				setFacetTranslator(createFacetTranslator(facetProcessor));
 
 				setFilterToQueryBuilderTranslator(
@@ -137,6 +145,16 @@ public class SearchRequestExecutorFixture {
 				setQueryToQueryBuilderTranslator(elasticsearchQueryTranslator);
 
 				setStatsTranslator(statsTranslator);
+			}
+		};
+	}
+
+	protected static ComplexQueryBuilderFactory
+		createComplexQueryBuilderFactory(Queries queries) {
+
+		return new ComplexQueryBuilderFactoryImpl() {
+			{
+				setQueries(queries);
 			}
 		};
 	}
@@ -201,11 +219,13 @@ public class SearchRequestExecutorFixture {
 		ElasticsearchQueryTranslator elasticsearchQueryTranslator,
 		ElasticsearchSortFieldTranslator elasticsearchSortFieldTranslator,
 		FacetProcessor facetProcessor, StatsTranslator statsTranslator,
-		StatsRequestBuilderFactory statsRequestBuilderFactory) {
+		StatsRequestBuilderFactory statsRequestBuilderFactory,
+		ComplexQueryBuilderFactory complexQueryBuilderFactory) {
 
 		CommonSearchSourceBuilderAssembler commonSearchSourceBuilderAssembler =
 			createCommonSearchSourceBuilderAssembler(
-				elasticsearchQueryTranslator, facetProcessor, statsTranslator);
+				elasticsearchQueryTranslator, facetProcessor, statsTranslator,
+				complexQueryBuilderFactory);
 
 		SearchSearchRequestAssembler searchSearchRequestAssembler =
 			createSearchSearchRequestAssembler(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchSortUnmappedFieldsTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/sort/ElasticsearchSortUnmappedFieldsTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.sort;
+
+import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.sort.BaseSortUnmappedFieldsTestCase;
+
+/**
+ * @author André de Oliveira
+ */
+public class ElasticsearchSortUnmappedFieldsTest
+	extends BaseSortUnmappedFieldsTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return LiferayElasticsearchIndexingFixtureFactory.getInstance();
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/document/DocumentTranslator.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/document/DocumentTranslator.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.document;
+
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.document.Document;
+
+import java.util.Map;
+
+/**
+ * @author André de Oliveira
+ */
+public class DocumentTranslator {
+
+	public com.liferay.portal.kernel.search.Document toLegacyDocument(
+		Document document) {
+
+		DocumentImpl documentImpl = new DocumentImpl();
+
+		Map<String, com.liferay.portal.search.document.Field> fields =
+			document.getFields();
+
+		fields.forEach(
+			(key, field) -> documentImpl.add(
+				new Field(key, String.valueOf(field.getValue()))));
+
+		return documentImpl;
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseMoreLikeThisQueryTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseMoreLikeThisQueryTestCase.java
@@ -212,13 +212,10 @@ public abstract class BaseMoreLikeThisQueryTestCase
 		assertSearch(
 			indexingTestHelper -> {
 				SearchSearchRequest searchSearchRequest =
-					new SearchSearchRequest();
+					createSearchSearchRequest();
 
-				searchSearchRequest.setIndexNames(
-					String.valueOf(getCompanyId()));
 				searchSearchRequest.setQuery(legacyMoreLikeThisQuery);
 				searchSearchRequest.setQuery(moreLikeThisQuery);
-				searchSearchRequest.setSize(30);
 
 				SearchEngineAdapter searchEngineAdapter =
 					getSearchEngineAdapter();
@@ -271,6 +268,15 @@ public abstract class BaseMoreLikeThisQueryTestCase
 		moreLikeThisQuery.setMinTermFrequency(Integer.valueOf(1));
 
 		assertSearch(null, moreLikeThisQuery, expectedValues);
+	}
+
+	protected SearchSearchRequest createSearchSearchRequest() {
+		SearchSearchRequest searchSearchRequest = new SearchSearchRequest();
+
+		searchSearchRequest.setIndexNames(String.valueOf(getCompanyId()));
+		searchSearchRequest.setSize(30);
+
+		return searchSearchRequest;
 	}
 
 	protected void deleteDocumentById(String id) {

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseSortUnmappedFieldsTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseSortUnmappedFieldsTestCase.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.sort;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.document.DocumentBuilder;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
+import com.liferay.portal.search.internal.filter.ComplexQueryPartBuilderFactoryImpl;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+
+import java.util.function.Consumer;
+
+import org.junit.Test;
+
+/**
+ * @author André de Oliveira
+ */
+public abstract class BaseSortUnmappedFieldsTestCase
+	extends BaseIndexingTestCase {
+
+	@Test
+	public void testDefaultIsTextMappingWithEmptyResults() {
+		String fieldName = RandomTestUtil.randomString();
+
+		addDocument(
+			builder().setString(fieldName, RandomTestUtil.randomString()));
+
+		assertSearch(fieldName, "[]");
+	}
+
+	@Test
+	public void testDefaultOnNewIndexIsEmptyResults() {
+		assertSearch(RandomTestUtil.randomString(), "[]");
+	}
+
+	@Test
+	public void testEmailAddressIsKeywordInLiferayTypeMappings() {
+		addDocument(
+			builder(
+			).setString(
+				"emailAddress", "dxp@liferay.com"
+			).setString(
+				"emailAddressDomain", "liferay.com"
+			));
+
+		assertSearch("emailAddress", "[dxp@liferay.com]");
+		assertSearch("emailAddress", "[]", withTerm("emailAddress", "dxp"));
+		assertSearch(
+			"emailAddress", "[]", withTerm("emailAddress", "liferay.com"));
+		assertSearch(
+			"emailAddress", "[dxp@liferay.com]",
+			withTerm("emailAddress", "dxp@liferay.com"));
+
+		assertSearch("emailAddressDomain", "[liferay.com]");
+		assertSearch(
+			"emailAddressDomain", "[]",
+			withTerm("emailAddressDomain", "liferay"));
+		assertSearch(
+			"emailAddressDomain", "[]", withTerm("emailAddressDomain", "com"));
+		assertSearch(
+			"emailAddressDomain", "[liferay.com]",
+			withTerm("emailAddressDomain", "liferay.com"));
+	}
+
+	@Test
+	public void testEmailAddressOnNewIndex() {
+		assertSearch("emailAddress", "[]");
+	}
+
+	@Test
+	public void testFirstNameIsTextMappingWithEmptyResults() {
+		addDocument(builder().setString("firstName", "Liferay DXP"));
+
+		assertSearch("firstName", "[]");
+		assertSearch("firstName", "[]", withTerm("firstName", "Liferay DXP"));
+	}
+
+	@Test
+	public void testFirstNameOnNewIndex() {
+		assertSearch("firstName", "[]");
+	}
+
+	@Test
+	public void testFirstNameStringSortable() {
+		addDocument(
+			builder(
+			).setString(
+				"firstName", "Liferay DXP"
+			).setString(
+				"firstName_String_sortable", "Liferay DXP"
+			));
+
+		assertSearch("firstName_String_sortable", "[Liferay DXP]");
+
+		assertSearch(
+			"firstName_String_sortable", "[Liferay DXP]",
+			withTerm("firstName", "dxp"));
+		assertSearch(
+			"firstName_String_sortable", "[]",
+			withTerm("firstName", "Liferay DXP"));
+
+		assertSearch(
+			"firstName_String_sortable", "[]",
+			withTerm("firstName_String_sortable", "dxp"));
+		assertSearch(
+			"firstName_String_sortable", "[Liferay DXP]",
+			withTerm("firstName_String_sortable", "Liferay DXP"));
+	}
+
+	@Test
+	public void testFirstNameStringSortableOnNewIndex() {
+		assertSearch("firstName_String_sortable", "[]");
+	}
+
+	@Test
+	public void testSortableKeyword() {
+		String fieldName1 = RandomTestUtil.randomString();
+
+		String fieldName2 = fieldName1 + "_String_sortable";
+
+		String fieldValue = RandomTestUtil.randomString();
+
+		addDocument(
+			builder(
+			).setString(
+				fieldName1, fieldValue
+			).setString(
+				fieldName2, fieldValue
+			));
+
+		assertSearch(fieldName1, "[]");
+		assertSearch(fieldName2, "[" + fieldValue + "]");
+	}
+
+	@Test
+	public void testSortableNumber() throws Throwable {
+		String fieldName1 = RandomTestUtil.randomString();
+
+		String fieldName2 = fieldName1 + "_Number_sortable";
+
+		int fieldValue = RandomTestUtil.randomInt();
+
+		addDocument(
+			builder(
+			).setInteger(
+				fieldName1, fieldValue
+			).setInteger(
+				fieldName2, fieldValue
+			));
+
+		assertSearch(fieldName1, "[]");
+		assertSearch(fieldName2, "[" + fieldValue + "]");
+	}
+
+	protected void assertSearch(
+		String fieldName, String expected,
+		Consumer<SearchRequestBuilder>... searchRequestBuilderConsumers) {
+
+		assertSearch(
+			indexingTestHelper -> {
+				indexingTestHelper.defineRequest(
+					searchRequestBuilder -> searchRequestBuilder.sorts(
+						sorts.field(fieldName)
+					).withSearchRequestBuilder(
+						searchRequestBuilderConsumers
+					));
+
+				indexingTestHelper.search();
+
+				indexingTestHelper.verifyResponse(
+					searchResponse -> DocumentsAssert.assertValues(
+						searchResponse.getRequestString(),
+						searchResponse.getDocumentsStream(), fieldName,
+						expected));
+			});
+	}
+
+	protected DocumentBuilder builder() {
+		return newDocumentBuilder();
+	}
+
+	protected Consumer<SearchRequestBuilder> withTerm(
+		String fieldName, String term) {
+
+		return searchRequestBuilder -> searchRequestBuilder.addComplexQueryPart(
+			complexQueryPartBuilderFactory.builder(
+			).query(
+				queries.term(fieldName, term)
+			).build());
+	}
+
+	protected final ComplexQueryPartBuilderFactory
+		complexQueryPartBuilderFactory =
+			new ComplexQueryPartBuilderFactoryImpl();
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/filter/ComplexQueryBuilderFactoryImpl.java
@@ -34,10 +34,17 @@ public class ComplexQueryBuilderFactoryImpl
 		return new ComplexQueryBuilderImpl(_queries, _scripts);
 	}
 
-	@Reference
-	private Queries _queries;
+	@Reference(unbind = "-")
+	protected void setQueries(Queries queries) {
+		_queries = queries;
+	}
 
-	@Reference
+	@Reference(unbind = "-")
+	protected void setScripts(Scripts scripts) {
+		_scripts = scripts;
+	}
+
+	private Queries _queries;
 	private Scripts _scripts;
 
 }


### PR DESCRIPTION
_Sort in SearchRequestBuilder fails on empty Elasticsearch index: "No mapping found for [field] in order to sort on"_
https://issues.liferay.com/browse/LPS-112287

_MoreLikeThisQueryTest is flaky under Elasticsearch 7_
https://issues.liferay.com/browse/LPS-112322