### PR TITLE
[TS] LPS-112283 portal-kernel: don't try creating destinations when destroying

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseSearchEngineConfigurator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseSearchEngineConfigurator.java
@@ -205,15 +205,19 @@ public abstract class BaseSearchEngineConfigurator
 	protected void destroySearchEngine(
 		SearchEngineRegistration searchEngineRegistration) {
 
-		Destination searchReaderDestination = getSearchReaderDestination(
-			_messageBus, searchEngineRegistration.getSearchEngineId());
+		Destination searchReaderDestination = _getSearchReaderDestination(
+			_messageBus, searchEngineRegistration.getSearchEngineId(), false);
 
-		searchReaderDestination.unregisterMessageListeners();
+		if (searchReaderDestination != null) {
+			searchReaderDestination.unregisterMessageListeners();
+		}
 
-		Destination searchWriterDestination = getSearchWriterDestination(
-			_messageBus, searchEngineRegistration.getSearchEngineId());
+		Destination searchWriterDestination = _getSearchWriterDestination(
+			_messageBus, searchEngineRegistration.getSearchEngineId(), false);
 
-		searchWriterDestination.unregisterMessageListeners();
+		if (searchWriterDestination != null) {
+			searchWriterDestination.unregisterMessageListeners();
+		}
 
 		SearchEngineHelper searchEngineHelper = getSearchEngineHelper();
 
@@ -235,13 +239,19 @@ public abstract class BaseSearchEngineConfigurator
 		SearchEngineProxyWrapper originalSearchEngineProxy =
 			searchEngineRegistration.getOriginalSearchEngineProxyWrapper();
 
-		registerInvokerMessageListener(
-			searchReaderDestination,
-			searchEngineRegistration.getOriginalSearchReaderMessageListeners());
+		if (searchReaderDestination != null) {
+			registerInvokerMessageListener(
+				searchReaderDestination,
+				searchEngineRegistration.
+					getOriginalSearchReaderMessageListeners());
+		}
 
-		registerInvokerMessageListener(
-			searchWriterDestination,
-			searchEngineRegistration.getOriginalSearchWriterMessageListeners());
+		if (searchWriterDestination != null) {
+			registerInvokerMessageListener(
+				searchWriterDestination,
+				searchEngineRegistration.
+					getOriginalSearchWriterMessageListeners());
+		}
 
 		setSearchEngine(
 			searchEngineRegistration.getSearchEngineId(),
@@ -274,45 +284,13 @@ public abstract class BaseSearchEngineConfigurator
 	protected Destination getSearchReaderDestination(
 		MessageBus messageBus, String searchEngineId) {
 
-		SearchEngineHelper searchEngineHelper = getSearchEngineHelper();
-
-		String searchReaderDestinationName =
-			searchEngineHelper.getSearchReaderDestinationName(searchEngineId);
-
-		Destination searchReaderDestination = messageBus.getDestination(
-			searchReaderDestinationName);
-
-		if (searchReaderDestination == null) {
-			searchReaderDestination = createSearchReaderDestination(
-				searchReaderDestinationName);
-
-			_registerSearchEngineDestination(
-				searchEngineId, searchReaderDestination);
-		}
-
-		return searchReaderDestination;
+		return _getSearchReaderDestination(messageBus, searchEngineId, true);
 	}
 
 	protected Destination getSearchWriterDestination(
 		MessageBus messageBus, String searchEngineId) {
 
-		SearchEngineHelper searchEngineHelper = getSearchEngineHelper();
-
-		String searchWriterDestinationName =
-			searchEngineHelper.getSearchWriterDestinationName(searchEngineId);
-
-		Destination searchWriterDestination = messageBus.getDestination(
-			searchWriterDestinationName);
-
-		if (searchWriterDestination == null) {
-			searchWriterDestination = createSearchWriterDestination(
-				searchWriterDestinationName);
-
-			_registerSearchEngineDestination(
-				searchEngineId, searchWriterDestination);
-		}
-
-		return searchWriterDestination;
+		return _getSearchWriterDestination(messageBus, searchEngineId, true);
 	}
 
 	protected void initialize() {
@@ -345,14 +323,14 @@ public abstract class BaseSearchEngineConfigurator
 
 		_searchEngineRegistrations.add(searchEngineRegistration);
 
-		Destination searchReaderDestination = getSearchReaderDestination(
-			_messageBus, searchEngineId);
+		Destination searchReaderDestination = _getSearchReaderDestination(
+			_messageBus, searchEngineId, true);
 
 		searchEngineRegistration.setSearchReaderDestinationName(
 			searchReaderDestination.getName());
 
-		Destination searchWriterDestination = getSearchWriterDestination(
-			_messageBus, searchEngineId);
+		Destination searchWriterDestination = _getSearchWriterDestination(
+			_messageBus, searchEngineId, true);
 
 		searchEngineRegistration.setSearchWriterDestinationName(
 			searchWriterDestination.getName());
@@ -455,6 +433,50 @@ public abstract class BaseSearchEngineConfigurator
 		searchEngineHelper.setSearchEngine(searchEngineId, searchEngine);
 
 		searchEngine.initialize(CompanyConstants.SYSTEM);
+	}
+
+	private Destination _getSearchReaderDestination(
+		MessageBus messageBus, String searchEngineId, boolean createIfAbsent) {
+
+		SearchEngineHelper searchEngineHelper = getSearchEngineHelper();
+
+		String searchReaderDestinationName =
+			searchEngineHelper.getSearchReaderDestinationName(searchEngineId);
+
+		Destination searchReaderDestination = messageBus.getDestination(
+			searchReaderDestinationName);
+
+		if (createIfAbsent && (searchReaderDestination == null)) {
+			searchReaderDestination = createSearchReaderDestination(
+				searchReaderDestinationName);
+
+			_registerSearchEngineDestination(
+				searchEngineId, searchReaderDestination);
+		}
+
+		return searchReaderDestination;
+	}
+
+	private Destination _getSearchWriterDestination(
+		MessageBus messageBus, String searchEngineId, boolean createIfAbsent) {
+
+		SearchEngineHelper searchEngineHelper = getSearchEngineHelper();
+
+		String searchWriterDestinationName =
+			searchEngineHelper.getSearchWriterDestinationName(searchEngineId);
+
+		Destination searchWriterDestination = messageBus.getDestination(
+			searchWriterDestinationName);
+
+		if (createIfAbsent && (searchWriterDestination == null)) {
+			searchWriterDestination = createSearchWriterDestination(
+				searchWriterDestinationName);
+
+			_registerSearchEngineDestination(
+				searchEngineId, searchWriterDestination);
+		}
+
+		return searchWriterDestination;
 	}
 
 	private void _registerSearchEngineDestination(


### PR DESCRIPTION
Author: @joshuacords

[x ci:test:search - 66 out of 69 jobs passed in 3 hours 20 minutes 11 seconds 545 ms](https://github.com/joshuacords/liferay-portal/pull/70#issuecomment-618073012)
All failing tests were known failures.

https://issues.liferay.com/browse/LPS-112283
https://issues.liferay.com/browse/LPP-37125
https://issues.liferay.com/browse/LPP-37009

**Problem:** During shutdown this stack is called. BaseSearchEngineConfiguration.destroySearchEngine()
BaseSearchEngineConfiguration.getSearchReaderDestination() 
BaseSearchEngineConfiguration.createSearchWriterDestination()
DestinationFactoryUtil.createDestination()

(getSearchWriterDestination() also follows this pattern)
The DestinationFacotryUtil.createDestination() relies a volatile [DestinationFactory](https://github.com/joshuacords/liferay-portal/blob/ceea8003b0c7b13ead87786739fa35384e6cfc7b/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationFactoryUtil.java#L24) that may not be present during shutdown. If it is not present, the shutdown process will hand and never complete.

**Solution:** There's no need for us to create a destination for the search writer or reader during the shutdown process. Therefore if the destination doesn't exist there's no MessageListeners to remove from it and we can safely continue. I also used private methods to avoid a major version increase.