### PR TITLE
LPS-113450 Elasticsearch 7: Fast unit tests, with either Embedded or Sidecar via feature flag + (Deflakes) LPS-111384, LPS-113837, LPS-113354

### DIFF
--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksEntryIndexerReindexTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksEntryIndexerReindexTest.java
@@ -18,20 +18,36 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.bookmarks.model.BookmarksEntry;
 import com.liferay.bookmarks.model.BookmarksFolder;
 import com.liferay.bookmarks.model.BookmarksFolderConstants;
+import com.liferay.bookmarks.service.BookmarksEntryLocalService;
+import com.liferay.bookmarks.service.BookmarksFolderService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.model.uid.UIDFactory;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.users.admin.test.util.search.GroupBlueprint;
+import com.liferay.users.admin.test.util.search.GroupSearchFixture;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -58,33 +74,52 @@ public class BookmarksEntryIndexerReindexTest {
 
 	@Before
 	public void setUp() throws Exception {
-		setUpUserSearchFixture();
+		Assert.assertEquals(
+			MODEL_INDEXER_CLASS.getName(), indexer.getClassName());
 
-		setUpBookmarksEntryFixture();
+		GroupSearchFixture groupSearchFixture = new GroupSearchFixture();
 
-		setUpBookmarksEntryIndexerFixture();
+		Group group = groupSearchFixture.addGroup(new GroupBlueprint());
 
-		setUpBookmarksFolderIndexerFixture();
+		UserSearchFixture userSearchFixture = new UserSearchFixture(
+			userLocalService, groupSearchFixture, null, null);
+
+		userSearchFixture.setUp();
+
+		User user = userSearchFixture.addUser(
+			RandomTestUtil.randomString(), group);
+
+		BookmarksFixture bookmarksFixture = new BookmarksFixture(
+			bookmarksEntryLocalService, bookmarksFolderService, group, user);
+
+		_bookmarksEntries = bookmarksFixture.getBookmarksEntries();
+		_bookmarksFixture = bookmarksFixture;
+		_bookmarksFolders = bookmarksFixture.getBookmarksFolders();
+
+		_group = group;
+		_groups = groupSearchFixture.getGroups();
+		_user = user;
+		_users = userSearchFixture.getUsers();
 	}
 
 	@Test
 	public void testReindex() throws Exception {
-		BookmarksEntry bookmarksEntry = bookmarksFixture.createBookmarksEntry();
+		BookmarksEntry bookmarksEntry =
+			_bookmarksFixture.createBookmarksEntry();
 
-		String searchTerm = bookmarksEntry.getUserName();
+		String searchTerm = StringUtil.toLowerCase(
+			bookmarksEntry.getUserName());
 
-		bookmarksEntryIndexerFixture.searchOnlyOne(searchTerm);
+		assertFieldValue(Field.USER_NAME, searchTerm, searchTerm);
 
-		Document document = bookmarksEntryIndexerFixture.searchOnlyOne(
-			searchTerm);
+		deleteDocument(
+			bookmarksEntry.getCompanyId(), uidFactory.getUID(bookmarksEntry));
 
-		bookmarksEntryIndexerFixture.deleteDocument(document);
+		assertNoHits(searchTerm);
 
-		bookmarksEntryIndexerFixture.searchNoOne(searchTerm);
+		reindexAllIndexerModels();
 
-		bookmarksEntryIndexerFixture.reindex(bookmarksEntry.getCompanyId());
-
-		bookmarksEntryIndexerFixture.searchOnlyOne(searchTerm);
+		assertFieldValue(Field.USER_NAME, searchTerm, searchTerm);
 	}
 
 	@Test
@@ -97,7 +132,7 @@ public class BookmarksEntryIndexerReindexTest {
 	@Test
 	public void testReindexEntriesInTheSameFolder() throws Exception {
 		BookmarksFolder bookmarksFolder =
-			bookmarksFixture.createBookmarksFolder();
+			_bookmarksFixture.createBookmarksFolder();
 
 		testReindexEntriesInFolder(bookmarksFolder.getFolderId());
 	}
@@ -105,74 +140,105 @@ public class BookmarksEntryIndexerReindexTest {
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
-	protected Document[] searchAndAssertLength(
-		String searchTerm, int expected) {
+	protected void assertFieldValue(
+		String fieldName, String fieldValue, String searchTerm) {
 
-		Document[] documents = bookmarksEntryIndexerFixture.search(searchTerm);
-
-		Assert.assertEquals(
-			Arrays.toString(documents), expected, documents.length);
-
-		return documents;
+		FieldValuesAssert.assertFieldValue(
+			fieldName, fieldValue, search(searchTerm));
 	}
 
-	protected void setUpBookmarksEntryFixture() throws Exception {
-		bookmarksFixture = new BookmarksFixture(_group, _user);
-
-		_bookmarksEntries = bookmarksFixture.getBookmarksEntries();
-
-		_bookmarksFolders = bookmarksFixture.getBookmarksFolders();
+	protected void assertNoHits(String searchTerm) {
+		FieldValuesAssert.assertFieldValues(
+			Collections.emptyMap(), search(searchTerm));
 	}
 
-	protected void setUpBookmarksEntryIndexerFixture() {
-		bookmarksEntryIndexerFixture = new IndexerFixture<>(
-			BookmarksEntry.class);
+	protected void deleteDocument(long companyId, String uid) throws Exception {
+		indexWriterHelper.deleteDocument(
+			indexer.getSearchEngineId(), companyId, uid, true);
 	}
 
-	protected void setUpBookmarksFolderIndexerFixture() {
-		bookmarksFolderIndexerFixture = new IndexerFixture<>(
-			BookmarksFolder.class);
+	protected void reindexAllIndexerModels() throws Exception {
+		indexer.reindex(new String[] {String.valueOf(_group.getCompanyId())});
 	}
 
-	protected void setUpUserSearchFixture() throws Exception {
-		userSearchFixture = new UserSearchFixture();
+	protected SearchResponse search(String searchTerm) {
+		return searcher.search(
+			searchRequestBuilderFactory.builder(
+			).companyId(
+				_group.getCompanyId()
+			).fields(
+				StringPool.STAR
+			).groupIds(
+				_group.getGroupId()
+			).modelIndexerClasses(
+				MODEL_INDEXER_CLASS
+			).ownerUserId(
+				_user.getUserId()
+			).queryString(
+				searchTerm
+			).build());
+	}
 
-		userSearchFixture.setUp();
+	protected void searchAndAssertLength(String searchTerm, int expected) {
+		SearchResponse searchResponse = search(searchTerm);
 
-		_group = userSearchFixture.addGroup();
+		List<Document> documents = searchResponse.getDocuments71();
 
-		_groups = userSearchFixture.getGroups();
-
-		_user = userSearchFixture.addUser(
-			RandomTestUtil.randomString(), _group);
-
-		_users = userSearchFixture.getUsers();
+		DocumentsAssert.assertCount(
+			searchResponse.getRequestString(),
+			documents.toArray(new Document[0]), Field.USER_NAME, expected);
 	}
 
 	protected void testReindexEntriesInFolder(long folderId) throws Exception {
-		BookmarksEntry bookmarksEntry = bookmarksFixture.createBookmarksEntry(
+		BookmarksEntry bookmarksEntry = _bookmarksFixture.createBookmarksEntry(
 			folderId);
 
-		bookmarksFixture.createBookmarksEntry(folderId);
+		_bookmarksFixture.createBookmarksEntry(folderId);
 
 		String searchTerm = _user.getFullName();
 
-		Document[] documents = searchAndAssertLength(searchTerm, 2);
+		searchAndAssertLength(searchTerm, 2);
 
-		bookmarksEntryIndexerFixture.deleteDocuments(documents);
+		deleteDocument(
+			bookmarksEntry.getCompanyId(), uidFactory.getUID(bookmarksEntry));
 
-		bookmarksEntryIndexerFixture.reindex(bookmarksEntry.getCompanyId());
+		reindexAllIndexerModels();
 
 		searchAndAssertLength(searchTerm, 2);
 	}
 
-	protected IndexerFixture<BookmarksEntry> bookmarksEntryIndexerFixture;
-	protected BookmarksFixture bookmarksFixture;
-	protected IndexerFixture<BookmarksFolder> bookmarksFolderIndexerFixture;
-	protected UserSearchFixture userSearchFixture;
+	protected static final Class<?> MODEL_INDEXER_CLASS = BookmarksEntry.class;
+
+	@Inject
+	protected BookmarksEntryLocalService bookmarksEntryLocalService;
+
+	@Inject
+	protected BookmarksFolderService bookmarksFolderService;
+
+	@Inject(
+		filter = "indexer.class.name=com.liferay.bookmarks.model.BookmarksEntry"
+	)
+	protected Indexer<BookmarksEntry> indexer;
+
+	@Inject
+	protected IndexWriterHelper indexWriterHelper;
+
+	@Inject
+	protected Searcher searcher;
+
+	@Inject
+	protected SearchRequestBuilderFactory searchRequestBuilderFactory;
+
+	@Inject
+	protected UIDFactory uidFactory;
+
+	@Inject
+	protected UserLocalService userLocalService;
 
 	@DeleteAfterTestRun
 	private List<BookmarksEntry> _bookmarksEntries;
+
+	private BookmarksFixture _bookmarksFixture;
 
 	@DeleteAfterTestRun
 	private List<BookmarksFolder> _bookmarksFolders;

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFixture.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFixture.java
@@ -17,8 +17,8 @@ package com.liferay.bookmarks.search.test;
 import com.liferay.bookmarks.model.BookmarksEntry;
 import com.liferay.bookmarks.model.BookmarksFolder;
 import com.liferay.bookmarks.model.BookmarksFolderConstants;
-import com.liferay.bookmarks.service.BookmarksEntryLocalServiceUtil;
-import com.liferay.bookmarks.test.util.BookmarksTestUtil;
+import com.liferay.bookmarks.service.BookmarksEntryLocalService;
+import com.liferay.bookmarks.service.BookmarksFolderService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -43,7 +43,12 @@ import java.util.Map;
  */
 public class BookmarksFixture {
 
-	public BookmarksFixture(Group group, User user) {
+	public BookmarksFixture(
+		BookmarksEntryLocalService bookmarksEntryLocalService,
+		BookmarksFolderService bookmarksFolderService, Group group, User user) {
+
+		_bookmarksEntryLocalService = bookmarksEntryLocalService;
+		_bookmarksFolderService = bookmarksFolderService;
 		_group = group;
 		_user = user;
 	}
@@ -68,7 +73,7 @@ public class BookmarksFixture {
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), _user.getUserId());
 
-		BookmarksEntry bookmarksEntry = BookmarksEntryLocalServiceUtil.addEntry(
+		BookmarksEntry bookmarksEntry = _bookmarksEntryLocalService.addEntry(
 			_user.getUserId(), _group.getGroupId(), folderId, name,
 			"https://www.liferay.com", description, serviceContext);
 
@@ -93,7 +98,7 @@ public class BookmarksFixture {
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), _user.getUserId());
 
-		BookmarksFolder bookmarksFolder = BookmarksTestUtil.addFolder(
+		BookmarksFolder bookmarksFolder = addFolder(
 			BookmarksFolderConstants.DEFAULT_PARENT_FOLDER_ID, name,
 			serviceContext);
 
@@ -139,8 +144,20 @@ public class BookmarksFixture {
 		_group.setModelAttributes(group.getModelAttributes());
 	}
 
+	protected BookmarksFolder addFolder(
+			long parentFolderId, String name, ServiceContext serviceContext)
+		throws Exception {
+
+		String description = "This is a test folder.";
+
+		return _bookmarksFolderService.addFolder(
+			parentFolderId, name, description, serviceContext);
+	}
+
 	private final List<BookmarksEntry> _bookmarksEntries = new ArrayList<>();
+	private final BookmarksEntryLocalService _bookmarksEntryLocalService;
 	private final List<BookmarksFolder> _bookmarksFolders = new ArrayList<>();
+	private final BookmarksFolderService _bookmarksFolderService;
 	private final Group _group;
 	private final User _user;
 

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderIndexerIndexedFieldsTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderIndexerIndexedFieldsTest.java
@@ -16,12 +16,13 @@ package com.liferay.bookmarks.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.bookmarks.model.BookmarksFolder;
+import com.liferay.bookmarks.service.BookmarksEntryLocalService;
+import com.liferay.bookmarks.service.BookmarksFolderService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -46,6 +47,7 @@ import com.liferay.users.admin.test.util.search.UserSearchFixture;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -70,6 +72,9 @@ public class BookmarksFolderIndexerIndexedFieldsTest {
 
 	@Before
 	public void setUp() throws Exception {
+		Assert.assertEquals(
+			MODEL_INDEXER_CLASS.getName(), indexer.getClassName());
+
 		GroupSearchFixture groupSearchFixture = new GroupSearchFixture();
 
 		Group group = groupSearchFixture.addGroup(new GroupBlueprint());
@@ -82,7 +87,8 @@ public class BookmarksFolderIndexerIndexedFieldsTest {
 		User user = userSearchFixture.addUser(
 			RandomTestUtil.randomString(), group);
 
-		BookmarksFixture bookmarksFixture = new BookmarksFixture(group, user);
+		BookmarksFixture bookmarksFixture = new BookmarksFixture(
+			bookmarksEntryLocalService, bookmarksFolderService, group, user);
 
 		_bookmarksFixture = bookmarksFixture;
 		_bookmarksFolders = bookmarksFixture.getBookmarksFolders();
@@ -130,13 +136,18 @@ public class BookmarksFolderIndexerIndexedFieldsTest {
 				).build()));
 	}
 
+	protected static final Class<?> MODEL_INDEXER_CLASS = BookmarksFolder.class;
+
+	@Inject
+	protected BookmarksEntryLocalService bookmarksEntryLocalService;
+
+	@Inject
+	protected BookmarksFolderService bookmarksFolderService;
+
 	@Inject(
 		filter = "indexer.class.name=com.liferay.bookmarks.model.BookmarksFolder"
 	)
 	protected Indexer<BookmarksFolder> indexer;
-
-	@Inject
-	protected IndexerRegistry indexerRegistry;
 
 	@Inject
 	protected ResourcePermissionLocalService resourcePermissionLocalService;

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderIndexerReindexTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/search/test/BookmarksFolderIndexerReindexTest.java
@@ -16,6 +16,8 @@ package com.liferay.bookmarks.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.bookmarks.model.BookmarksFolder;
+import com.liferay.bookmarks.service.BookmarksEntryLocalService;
+import com.liferay.bookmarks.service.BookmarksFolderService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
@@ -44,6 +46,7 @@ import com.liferay.users.admin.test.util.search.UserSearchFixture;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -68,6 +71,9 @@ public class BookmarksFolderIndexerReindexTest {
 
 	@Before
 	public void setUp() throws Exception {
+		Assert.assertEquals(
+			MODEL_INDEXER_CLASS.getName(), indexer.getClassName());
+
 		GroupSearchFixture groupSearchFixture = new GroupSearchFixture();
 
 		Group group = groupSearchFixture.addGroup(new GroupBlueprint());
@@ -80,7 +86,8 @@ public class BookmarksFolderIndexerReindexTest {
 		User user = userSearchFixture.addUser(
 			RandomTestUtil.randomString(), group);
 
-		BookmarksFixture bookmarksFixture = new BookmarksFixture(group, user);
+		BookmarksFixture bookmarksFixture = new BookmarksFixture(
+			bookmarksEntryLocalService, bookmarksFolderService, group, user);
 
 		_group = group;
 
@@ -151,6 +158,14 @@ public class BookmarksFolderIndexerReindexTest {
 				searchTerm
 			).build());
 	}
+
+	protected static final Class<?> MODEL_INDEXER_CLASS = BookmarksFolder.class;
+
+	@Inject
+	protected BookmarksEntryLocalService bookmarksEntryLocalService;
+
+	@Inject
+	protected BookmarksFolderService bookmarksFolderService;
 
 	@Inject(
 		filter = "indexer.class.name=com.liferay.bookmarks.model.BookmarksFolder"

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexWriter.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/ElasticsearchIndexWriter.java
@@ -47,6 +47,8 @@ import com.liferay.portal.search.index.IndexNameBuilder;
 import java.util.Collection;
 import java.util.Map;
 
+import org.elasticsearch.index.IndexNotFoundException;
+
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
@@ -167,7 +169,14 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 		}
 		catch (RuntimeException runtimeException) {
 			if (_logExceptionsOnly) {
-				_log.error(runtimeException, runtimeException);
+				if (isIndexNotFound(runtimeException)) {
+					if (_log.isInfoEnabled()) {
+						_log.info(runtimeException, runtimeException);
+					}
+				}
+				else {
+					_log.error(runtimeException, runtimeException);
+				}
 			}
 			else {
 				throw runtimeException;
@@ -421,6 +430,14 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 			ElasticsearchConfiguration.class, properties);
 
 		_logExceptionsOnly = _elasticsearchConfiguration.logExceptionsOnly();
+	}
+
+	protected boolean isIndexNotFound(RuntimeException runtimeException) {
+		if (runtimeException instanceof IndexNotFoundException) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexSearcherLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexSearcherLogExceptionsOnlyTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexSearcher;
 import com.liferay.portal.search.elasticsearch6.internal.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
@@ -27,6 +28,7 @@ import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.logging.ExpectedLogTestRule;
 
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,7 +56,8 @@ public class ElasticsearchIndexSearcherLogExceptionsOnlyTest
 	}
 
 	@Rule
-	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.none();
+	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.with(
+		ElasticsearchIndexSearcher.class, Level.WARNING);
 
 	protected ElasticsearchFixture createElasticsearchFixture() {
 		Map<String, Object> elasticsearchConfigurationProperties =

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexWriter;
 import com.liferay.portal.search.elasticsearch6.internal.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.document.BulkDocumentRequestExecutorImpl;
@@ -344,7 +345,8 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Rule
-	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.none();
+	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.with(
+		ElasticsearchIndexWriter.class, Level.WARNING);
 
 	protected ElasticsearchFixture createElasticsearchFixture() {
 		Map<String, Object> elasticsearchConfigurationProperties =

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
+import org.hamcrest.CoreMatchers;
+
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -118,7 +120,29 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 	@Test
 	public void testDeleteDocument() {
-		expectedLogTestRule.expectMessage("no such index");
+		expectedLogTestRule.expectMessage(
+			CoreMatchers.not(CoreMatchers.containsString("no such index")));
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.deleteDocument(searchContext, "1");
+		}
+		catch (SearchException searchException) {
+		}
+	}
+
+	@Test
+	public void testDeleteDocumentInfoLevel() {
+		expectedLogTestRule.configure(
+			ElasticsearchIndexWriter.class, Level.INFO);
+
+		expectedLogTestRule.expectMessage(
+			CoreMatchers.containsString("no such index"));
 
 		SearchContext searchContext = new SearchContext();
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -214,6 +214,10 @@ processResources {
 	}
 }
 
+test {
+	forkEvery = 0
+}
+
 _createPluginTasks(elasticsearchVersion, sidecarPluginURLs)
 
 private void _createPluginTasks(String elasticsearchVersion, List<String> sidecarPluginURLs) {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -3,11 +3,19 @@ import com.liferay.gradle.util.StringUtil
 
 task cleanSidecar
 task deploySidecar(type: Copy)
+task deployTestSidecar(type: Copy)
+task deployTestSidecarDependencies
 
 String elasticsearchVersion = "7.3.0"
 String luceneVersion = "8.1.0"
 
-File sidecarDir = file("${project.'liferay.home'}/elasticsearch" + elasticsearchVersion.substring(0, 1))
+String elasticsearchDownloadURL = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${elasticsearchVersion}-no-jdk-linux-x86_64.tar.gz"
+
+File elasticsearchDistributionFile = file("${buildDir}/${elasticsearchDownloadURL.drop(elasticsearchDownloadURL.lastIndexOf('/') + 1)}")
+
+File sidecarDeployDir = file("${project.'liferay.home'}/elasticsearch" + elasticsearchVersion.substring(0, 1))
+File sidecarTestDir = file("tmp/sidecar-elasticsearch")
+
 List<String> sidecarPluginURLs = [
 	"https://artifacts.elastic.co/downloads/elasticsearch-plugins/analysis-icu/analysis-icu-${elasticsearchVersion}.zip",
 	"https://artifacts.elastic.co/downloads/elasticsearch-plugins/analysis-kuromoji/analysis-kuromoji-${elasticsearchVersion}.zip",
@@ -120,7 +128,11 @@ dependencies {
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:petra:petra-concurrent")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
+	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-memory")
+	compileOnly project(":core:petra:petra-nio")
 	compileOnly project(":core:petra:petra-process")
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")
@@ -144,9 +156,6 @@ dependencies {
 	testCompile group: "org.slf4j", name: "slf4j-api", version: "1.7.26"
 	testCompile project(":apps:portal-search:portal-search")
 	testCompile project(":apps:portal-search:portal-search-test-util")
-	testCompile project(":core:petra:petra-lang")
-	testCompile project(":core:petra:petra-memory")
-	testCompile project(":core:petra:petra-nio")
 	testCompile project(":core:petra:petra-sql-dsl-api")
 	testCompile project(":core:registry-api")
 }
@@ -171,9 +180,9 @@ deploySidecar {
 	description = "Assembles the Elasticsearch sidecar and deploys it to Liferay."
 	group = "build"
 
-	destinationDir = sidecarDir
+	destinationDir = sidecarDeployDir
 
-	enabled = !sidecarDir.exists()
+	enabled = !destinationDir.exists()
 
 	ext {
 		autoClean = false
@@ -184,11 +193,7 @@ deploySidecar {
 	}
 
 	doFirst {
-		String url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${elasticsearchVersion}-no-jdk-linux-x86_64.tar.gz"
-
-		File file = file("${buildDir}/${url.drop(url.lastIndexOf('/') + 1)}")
-
-		FileUtil.get(project, url, file, false, true)
+		FileUtil.get(project, elasticsearchDownloadURL, elasticsearchDistributionFile, false, true)
 
 		project.copy {
 			fileMode = 0777
@@ -199,12 +204,74 @@ deploySidecar {
 			include "elasticsearch-${elasticsearchVersion}/modules/**"
 
 			into buildDir
-			from tarTree(file)
+			from tarTree(elasticsearchDistributionFile)
 		}
 	}
 
 	doLast {
 		logger.lifecycle "Deployed Elasticsearch Sidecar: {}", destinationDir
+	}
+}
+
+deployTestSidecar {
+	dependsOn cleanSidecar
+
+	description = "Assembles the Elasticsearch sidecar and deploys it to build test directory."
+	group = "build"
+
+	destinationDir = sidecarTestDir
+
+	enabled = !destinationDir.exists()
+
+	ext {
+		autoClean = false
+	}
+
+	from {
+		file("${buildDir}/elasticsearch-" + elasticsearchVersion)
+	}
+
+	doFirst {
+		FileUtil.get(project, elasticsearchDownloadURL, elasticsearchDistributionFile, false, true)
+
+		project.copy {
+			fileMode = 0777
+			includeEmptyDirs = false
+
+			exclude "elasticsearch-${elasticsearchVersion}/modules/ingest-geoip/**"
+			include "elasticsearch-${elasticsearchVersion}/lib/**"
+			include "elasticsearch-${elasticsearchVersion}/modules/**"
+
+			into buildDir
+			from tarTree(elasticsearchDistributionFile)
+		}
+	}
+
+	doLast {
+		logger.lifecycle "Deployed Elasticsearch Sidecar: {}", destinationDir
+	}
+}
+
+deployTestSidecarDependencies {
+	dependsOn configurations.compileOnly
+
+	doLast {
+		File libProcessExecutorDir = file("tmp/lib-process-executor")
+
+		if (!libProcessExecutorDir.exists()) {
+			libProcessExecutorDir.mkdir()
+		}
+
+		project.copy {
+			include "com.liferay.petra.*.jar"
+
+			configurations.compileOnly.allDependencies.each {
+				rename "-${it.version}", ""
+			}
+
+			into libProcessExecutorDir.getPath()
+			from configurations.compileOnly
+		}
 	}
 }
 
@@ -215,6 +282,10 @@ processResources {
 }
 
 test {
+	dependsOn deployTestSidecar
+
+	dependsOn deployTestSidecarDependencies
+
 	forkEvery = 0
 }
 
@@ -247,6 +318,8 @@ private void _createPluginTasks(String elasticsearchVersion, List<String> sideca
 		}
 
 		deploySidecar.dependsOn installPluginTask
+
+		deployTestSidecar.dependsOn installPluginTask
 
 		installPluginTask.mustRunAfter cleanSidecar
 	}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexWriter.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexWriter.java
@@ -47,6 +47,8 @@ import com.liferay.portal.search.index.IndexNameBuilder;
 import java.util.Collection;
 import java.util.Map;
 
+import org.elasticsearch.ElasticsearchStatusException;
+
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
@@ -167,7 +169,14 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 		}
 		catch (RuntimeException runtimeException) {
 			if (_logExceptionsOnly) {
-				_log.error(runtimeException, runtimeException);
+				if (isIndexNotFound(runtimeException)) {
+					if (_log.isInfoEnabled()) {
+						_log.info(runtimeException, runtimeException);
+					}
+				}
+				else {
+					_log.error(runtimeException, runtimeException);
+				}
 			}
 			else {
 				throw runtimeException;
@@ -421,6 +430,18 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 			ElasticsearchConfiguration.class, properties);
 
 		_logExceptionsOnly = _elasticsearchConfiguration.logExceptionsOnly();
+	}
+
+	protected boolean isIndexNotFound(RuntimeException runtimeException) {
+		if (runtimeException instanceof ElasticsearchStatusException) {
+			String message = runtimeException.getMessage();
+
+			if (message.contains("type=index_not_found_exception")) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchInstancePaths.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchInstancePaths.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.connection;
+
+import java.nio.file.Path;
+
+/**
+ * @author André de Oliveira
+ */
+public interface ElasticsearchInstancePaths {
+
+	public Path getHomePath();
+
+	public Path getWorkPath();
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchInstanceSettingsBuilder.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchInstanceSettingsBuilder.java
@@ -1,0 +1,337 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.connection;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.PortalRunMode;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration;
+import com.liferay.portal.search.elasticsearch7.internal.settings.SettingsBuilder;
+import com.liferay.portal.search.elasticsearch7.internal.util.ResourceUtil;
+import com.liferay.portal.search.elasticsearch7.settings.ClientSettingsHelper;
+import com.liferay.portal.search.elasticsearch7.settings.SettingsContributor;
+
+import java.net.InetAddress;
+
+import java.nio.file.Path;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import org.elasticsearch.common.settings.Settings;
+
+/**
+ * @author André de Oliveira
+ */
+public class ElasticsearchInstanceSettingsBuilder {
+
+	public static ElasticsearchInstanceSettingsBuilder builder() {
+		return new ElasticsearchInstanceSettingsBuilder();
+	}
+
+	public ElasticsearchInstanceSettingsBuilder() {
+	}
+
+	public Settings build() {
+		load();
+
+		Settings.Builder builder = _settingsBuilder.getBuilder();
+
+		return builder.build();
+	}
+
+	public ElasticsearchInstanceSettingsBuilder clusterInitialMasterNodes(
+		String clusterInitialMasterNodes) {
+
+		_clusterInitialMasterNodes = clusterInitialMasterNodes;
+
+		return this;
+	}
+
+	public ElasticsearchInstanceSettingsBuilder clusterName(
+		String clusterName) {
+
+		_clusterName = clusterName;
+
+		return this;
+	}
+
+	public ElasticsearchInstanceSettingsBuilder discoverySeedHosts(
+		String discoverySeedHosts) {
+
+		_discoverySeedHosts = discoverySeedHosts;
+
+		return this;
+	}
+
+	public ElasticsearchInstanceSettingsBuilder elasticsearchConfiguration(
+		ElasticsearchConfiguration elasticsearchConfiguration) {
+
+		_elasticsearchConfiguration = elasticsearchConfiguration;
+
+		return this;
+	}
+
+	public ElasticsearchInstanceSettingsBuilder elasticsearchInstancePaths(
+		ElasticsearchInstancePaths elasticsearchInstancePaths) {
+
+		_elasticsearchInstancePaths = elasticsearchInstancePaths;
+
+		return this;
+	}
+
+	public ElasticsearchInstanceSettingsBuilder httpPort(String httpPort) {
+		_httpPort = httpPort;
+
+		return this;
+	}
+
+	public ElasticsearchInstanceSettingsBuilder localBindInetAddressSupplier(
+		Supplier<InetAddress> localBindInetAddressSupplier) {
+
+		_localBindInetAddressSupplier = localBindInetAddressSupplier;
+
+		return this;
+	}
+
+	public ElasticsearchInstanceSettingsBuilder networkHost(
+		String networkHost) {
+
+		_networkHost = networkHost;
+
+		return this;
+	}
+
+	public ElasticsearchInstanceSettingsBuilder nodeName(String nodeName) {
+		_nodeName = nodeName;
+
+		return this;
+	}
+
+	public ElasticsearchInstanceSettingsBuilder settingsContributors(
+		Collection<SettingsContributor> settingsContributors) {
+
+		_settingsContributors = settingsContributors;
+
+		return this;
+	}
+
+	public interface LocalBindInetAddressSupplier
+		extends Supplier<InetAddress> {
+	}
+
+	protected void configureClustering() {
+		put("cluster.name", _clusterName);
+		put("cluster.routing.allocation.disk.threshold_enabled", false);
+
+		if (Validator.isBlank(_clusterInitialMasterNodes)) {
+			put("discovery.type", "single-node");
+		}
+	}
+
+	protected void configureHttp() {
+		put("http.port", _httpPort);
+
+		put("http.cors.enabled", _elasticsearchConfiguration.httpCORSEnabled());
+
+		if (!_elasticsearchConfiguration.httpCORSEnabled()) {
+			return;
+		}
+
+		put(
+			"http.cors.allow-origin",
+			_elasticsearchConfiguration.httpCORSAllowOrigin());
+
+		_settingsBuilder.loadFromSource(
+			_elasticsearchConfiguration.httpCORSConfigurations());
+	}
+
+	protected void configureNetworking() {
+		String networkBindHost = _elasticsearchConfiguration.networkBindHost();
+		String networkHost = _elasticsearchConfiguration.networkHost();
+		String networkPublishHost =
+			_elasticsearchConfiguration.networkPublishHost();
+
+		if (Validator.isNotNull(networkBindHost)) {
+			put("network.bind.host", networkBindHost);
+		}
+
+		if (!Validator.isBlank(_networkHost)) {
+			put("network.host", _networkHost);
+		}
+		else {
+			if (Validator.isNull(networkBindHost) &&
+				Validator.isNull(networkHost) &&
+				Validator.isNull(networkPublishHost)) {
+
+				InetAddress inetAddress = _localBindInetAddressSupplier.get();
+
+				if (inetAddress != null) {
+					networkHost = inetAddress.getHostAddress();
+				}
+			}
+
+			if (Validator.isNotNull(networkHost)) {
+				put("network.host", networkHost);
+			}
+		}
+
+		if (Validator.isNotNull(networkPublishHost)) {
+			put("network.publish_host", networkPublishHost);
+		}
+
+		String transportTcpPort =
+			_elasticsearchConfiguration.transportTcpPort();
+
+		if (Validator.isNotNull(transportTcpPort)) {
+			put("transport.tcp.port", transportTcpPort);
+		}
+
+		put("transport.type", "netty4");
+	}
+
+	protected void configurePaths() {
+		Path workPath = _elasticsearchInstancePaths.getWorkPath();
+
+		Path dataParentPath = workPath.resolve("data/elasticsearch7");
+
+		Path homePath = getHomePath();
+
+		put("path.data", String.valueOf(dataParentPath.resolve("indices")));
+
+		put("path.home", String.valueOf(homePath.toAbsolutePath()));
+
+		put("path.logs", String.valueOf(workPath.resolve("logs")));
+
+		put("path.repo", String.valueOf(dataParentPath.resolve("repo")));
+	}
+
+	protected void configureTestMode() {
+		if (!PortalRunMode.isTestMode()) {
+			return;
+		}
+
+		put("monitor.jvm.gc.enabled", StringPool.FALSE);
+	}
+
+	protected Path getHomePath() {
+		Path homePath = _elasticsearchInstancePaths.getHomePath();
+
+		if (homePath != null) {
+			return homePath;
+		}
+
+		Path workPath = _elasticsearchInstancePaths.getWorkPath();
+
+		return workPath.resolve("data/elasticsearch7");
+	}
+
+	protected void load() {
+		loadDefaultConfigurations();
+
+		loadSidecarConfigurations();
+
+		loadAdditionalConfigurations();
+
+		loadSettingsContributors();
+	}
+
+	protected void loadAdditionalConfigurations() {
+		_settingsBuilder.loadFromSource(
+			_elasticsearchConfiguration.additionalConfigurations());
+	}
+
+	protected void loadDefaultConfigurations() {
+		String defaultConfigurations = ResourceUtil.getResourceAsString(
+			getClass(), "/META-INF/elasticsearch-optional-defaults.yml");
+
+		_settingsBuilder.loadFromSource(defaultConfigurations);
+
+		put("action.auto_create_index", false);
+		put(
+			"bootstrap.memory_lock",
+			_elasticsearchConfiguration.bootstrapMlockAll());
+
+		configureClustering();
+
+		configureHttp();
+
+		configureNetworking();
+
+		put("node.data", true);
+		put("node.ingest", true);
+		put("node.master", true);
+		put("node.name", _nodeName);
+
+		configurePaths();
+
+		configureTestMode();
+	}
+
+	protected void loadSettingsContributors() {
+		ClientSettingsHelper clientSettingsHelper = new ClientSettingsHelper() {
+
+			@Override
+			public void put(String setting, String value) {
+				_settingsBuilder.put(setting, value);
+			}
+
+			@Override
+			public void putArray(String setting, String... values) {
+				_settingsBuilder.putList(setting, values);
+			}
+
+		};
+
+		for (SettingsContributor settingsContributor : _settingsContributors) {
+			settingsContributor.populate(clientSettingsHelper);
+		}
+	}
+
+	protected void loadSidecarConfigurations() {
+		put("bootstrap.system_call_filter", false);
+		put("node.store.allow_mmap", false);
+
+		if (!Validator.isBlank(_clusterInitialMasterNodes)) {
+			put("cluster.initial_master_nodes", _clusterInitialMasterNodes);
+		}
+
+		if (!Validator.isBlank(_discoverySeedHosts)) {
+			put("discovery.seed_hosts", _discoverySeedHosts);
+		}
+	}
+
+	protected void put(String key, boolean value) {
+		_settingsBuilder.put(key, value);
+	}
+
+	protected void put(String key, String value) {
+		_settingsBuilder.put(key, value);
+	}
+
+	private String _clusterInitialMasterNodes;
+	private String _clusterName;
+	private String _discoverySeedHosts;
+	private ElasticsearchConfiguration _elasticsearchConfiguration;
+	private ElasticsearchInstancePaths _elasticsearchInstancePaths;
+	private String _httpPort;
+	private Supplier<InetAddress> _localBindInetAddressSupplier;
+	private String _networkHost;
+	private String _nodeName;
+	private final SettingsBuilder _settingsBuilder = new SettingsBuilder(
+		Settings.builder());
+	private Collection<SettingsContributor> _settingsContributors;
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/EmbeddedElasticsearchConnection.java
@@ -15,29 +15,25 @@
 package com.liferay.portal.search.elasticsearch7.internal.connection;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.File;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration;
 import com.liferay.portal.search.elasticsearch7.internal.cluster.ClusterSettingsContext;
-import com.liferay.portal.search.elasticsearch7.internal.settings.SettingsBuilder;
-import com.liferay.portal.search.elasticsearch7.internal.util.ClassLoaderUtil;
 import com.liferay.portal.search.elasticsearch7.internal.util.LogUtil;
-import com.liferay.portal.search.elasticsearch7.internal.util.ResourceUtil;
-import com.liferay.portal.search.elasticsearch7.settings.ClientSettingsHelper;
 import com.liferay.portal.search.elasticsearch7.settings.SettingsContributor;
 
 import io.netty.buffer.ByteBufUtil;
 
 import java.io.IOException;
 
-import java.net.InetAddress;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import java.util.Map;
 import java.util.Set;
@@ -48,10 +44,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.time.StopWatch;
-import org.apache.http.HttpHost;
 import org.apache.logging.log4j.LogManager;
 
-import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.settings.Settings;
@@ -149,10 +143,6 @@ public class EmbeddedElasticsearchConnection
 		return String.valueOf(OperationMode.EMBEDDED);
 	}
 
-	public Node getNode() {
-		return _node;
-	}
-
 	@Override
 	public OperationMode getOperationMode() {
 		return OperationMode.EMBEDDED;
@@ -171,6 +161,8 @@ public class EmbeddedElasticsearchConnection
 		elasticsearchConfiguration = ConfigurableUtil.createConfigurable(
 			ElasticsearchConfiguration.class, properties);
 
+		_httpPort = (String)properties.get("sidecarHttpPort");
+
 		java.io.File tempDir = bundleContext.getDataFile(JNA_TMP_DIR);
 
 		_jnaTmpDirName = tempDir.getAbsolutePath();
@@ -188,95 +180,6 @@ public class EmbeddedElasticsearchConnection
 		SettingsContributor settingsContributor) {
 
 		_settingsContributors.add(settingsContributor);
-	}
-
-	protected void configureClustering() {
-		settingsBuilder.put(
-			"cluster.name", elasticsearchConfiguration.clusterName());
-		settingsBuilder.put(
-			"cluster.routing.allocation.disk.threshold_enabled", false);
-		settingsBuilder.put("discovery.type", "single-node");
-	}
-
-	protected void configureHttp() {
-		settingsBuilder.put(
-			"http.port",
-			String.valueOf(elasticsearchConfiguration.embeddedHttpPort()));
-
-		settingsBuilder.put(
-			"http.cors.enabled", elasticsearchConfiguration.httpCORSEnabled());
-
-		if (!elasticsearchConfiguration.httpCORSEnabled()) {
-			return;
-		}
-
-		settingsBuilder.put(
-			"http.cors.allow-origin",
-			elasticsearchConfiguration.httpCORSAllowOrigin());
-
-		settingsBuilder.loadFromSource(
-			elasticsearchConfiguration.httpCORSConfigurations());
-	}
-
-	protected void configureNetworking() {
-		String networkBindHost = elasticsearchConfiguration.networkBindHost();
-
-		if (Validator.isNotNull(networkBindHost)) {
-			settingsBuilder.put("network.bind.host", networkBindHost);
-		}
-
-		String networkHost = elasticsearchConfiguration.networkHost();
-
-		if (Validator.isNull(networkBindHost) &&
-			Validator.isNull(networkHost) &&
-			Validator.isNull(elasticsearchConfiguration.networkPublishHost())) {
-
-			InetAddress localBindInetAddress =
-				clusterSettingsContext.getLocalBindInetAddress();
-
-			if (localBindInetAddress != null) {
-				networkHost = localBindInetAddress.getHostAddress();
-			}
-		}
-
-		if (Validator.isNotNull(networkHost)) {
-			settingsBuilder.put("network.host", networkHost);
-		}
-
-		String networkPublishHost =
-			elasticsearchConfiguration.networkPublishHost();
-
-		if (Validator.isNotNull(networkPublishHost)) {
-			settingsBuilder.put("network.publish_host", networkPublishHost);
-		}
-
-		String transportTcpPort = elasticsearchConfiguration.transportTcpPort();
-
-		if (Validator.isNotNull(transportTcpPort)) {
-			settingsBuilder.put("transport.tcp.port", transportTcpPort);
-		}
-
-		settingsBuilder.put("transport.type", "netty4");
-	}
-
-	protected void configurePaths() {
-		String liferayHome = props.get(PropsKeys.LIFERAY_HOME);
-
-		settingsBuilder.put(
-			"path.data", liferayHome.concat("/data/elasticsearch7/indices"));
-		settingsBuilder.put(
-			"path.home", liferayHome.concat("/data/elasticsearch7"));
-		settingsBuilder.put("path.logs", liferayHome.concat("/logs"));
-		settingsBuilder.put(
-			"path.repo", liferayHome.concat("/data/elasticsearch7/repo"));
-	}
-
-	protected void configureTestMode() {
-		if (!PortalRunMode.isTestMode()) {
-			return;
-		}
-
-		settingsBuilder.put("monitor.jvm.gc.enabled", StringPool.FALSE);
 	}
 
 	protected EmbeddedElasticsearchPluginManager
@@ -326,21 +229,39 @@ public class EmbeddedElasticsearchConnection
 
 		startNode();
 
-		Class<? extends EmbeddedElasticsearchConnection> clazz = getClass();
-
-		return ClassLoaderUtil.getWithContextClassLoader(
-			() -> new RestHighLevelClient(
-				RestClient.builder(
-					new HttpHost(
-						"localhost",
-						elasticsearchConfiguration.embeddedHttpPort(),
-						"http"))),
-			clazz);
+		return RestHighLevelClientFactory.builder(
+		).clusterName(
+			getClusterName()
+		).hostName(
+			"localhost"
+		).nodeName(
+			getNodeName()
+		).portRange(
+			getHttpPort()
+		).scheme(
+			"http"
+		).build(
+		).getRestHighLevelClientOptional(
+		).get();
 	}
 
 	@Deactivate
 	protected void deactivate(Map<String, Object> properties) {
 		close();
+	}
+
+	protected String getClusterName() {
+		return elasticsearchConfiguration.clusterName();
+	}
+
+	protected String getHttpPort() {
+		return GetterUtil.getString(
+			_httpPort,
+			String.valueOf(elasticsearchConfiguration.embeddedHttpPort()));
+	}
+
+	protected String getNodeName() {
+		return "liferay";
 	}
 
 	protected void installPlugin(String name, Settings settings) {
@@ -373,58 +294,6 @@ public class EmbeddedElasticsearchConnection
 		LogManager.shutdown();
 	}
 
-	protected void loadAdditionalConfigurations() {
-		settingsBuilder.loadFromSource(
-			elasticsearchConfiguration.additionalConfigurations());
-	}
-
-	protected void loadDefaultConfigurations() {
-		String defaultConfigurations = ResourceUtil.getResourceAsString(
-			getClass(), "/META-INF/elasticsearch-optional-defaults.yml");
-
-		settingsBuilder.loadFromSource(defaultConfigurations);
-
-		settingsBuilder.put("action.auto_create_index", false);
-		settingsBuilder.put(
-			"bootstrap.memory_lock",
-			elasticsearchConfiguration.bootstrapMlockAll());
-
-		configureClustering();
-
-		configureHttp();
-
-		configureNetworking();
-
-		settingsBuilder.put("node.data", true);
-		settingsBuilder.put("node.ingest", true);
-		settingsBuilder.put("node.master", true);
-		settingsBuilder.put("node.name", "liferay");
-
-		configurePaths();
-
-		configureTestMode();
-	}
-
-	protected void loadSettingsContributors() {
-		ClientSettingsHelper clientSettingsHelper = new ClientSettingsHelper() {
-
-			@Override
-			public void put(String setting, String value) {
-				settingsBuilder.put(setting, value);
-			}
-
-			@Override
-			public void putArray(String setting, String... values) {
-				settingsBuilder.putList(setting, values);
-			}
-
-		};
-
-		for (SettingsContributor settingsContributor : _settingsContributors) {
-			settingsContributor.populate(clientSettingsHelper);
-		}
-	}
-
 	protected void removeObsoletePlugin(String name, Settings settings) {
 		EmbeddedElasticsearchPluginManager embeddedElasticsearchPluginManager =
 			createEmbeddedElasticsearchPluginManager(name, settings);
@@ -445,12 +314,6 @@ public class EmbeddedElasticsearchConnection
 	}
 
 	protected void startNode() {
-		loadDefaultConfigurations();
-
-		loadAdditionalConfigurations();
-
-		loadSettingsContributors();
-
 		StopWatch stopWatch = new StopWatch();
 
 		stopWatch.start();
@@ -470,12 +333,28 @@ public class EmbeddedElasticsearchConnection
 			_log.warn(sb.toString());
 		}
 
-		Settings settings = settingsBuilder.build();
+		Settings settings = ElasticsearchInstanceSettingsBuilder.builder(
+		).clusterName(
+			getClusterName()
+		).elasticsearchConfiguration(
+			elasticsearchConfiguration
+		).elasticsearchInstancePaths(
+			new EmbeddedElasticsearchInstancePaths()
+		).httpPort(
+			getHttpPort()
+		).localBindInetAddressSupplier(
+			clusterSettingsContext::getLocalBindInetAddress
+		).nodeName(
+			getNodeName()
+		).settingsContributors(
+			_settingsContributors
+		).build();
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(
-				"Starting embedded Elasticsearch cluster " +
-					elasticsearchConfiguration.clusterName());
+				StringBundler.concat(
+					"Starting embedded Elasticsearch cluster ",
+					getClusterName(), " with settings: ", settings.toString()));
 		}
 
 		_node = createNode(settings);
@@ -492,8 +371,8 @@ public class EmbeddedElasticsearchConnection
 
 			_log.debug(
 				StringBundler.concat(
-					"Started ", elasticsearchConfiguration.clusterName(),
-					" in ", stopWatch.getTime(), " ms"));
+					"Started ", getClusterName(), " in ", stopWatch.getTime(),
+					" ms"));
 		}
 	}
 
@@ -507,29 +386,23 @@ public class EmbeddedElasticsearchConnection
 	@Reference
 	protected Props props;
 
-	protected SettingsBuilder settingsBuilder = new SettingsBuilder(
-		Settings.builder());
+	private static void _logRejectedExecution(
+		Runnable runnable, ThreadPoolExecutor threadPoolExecutor) {
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Discarded ", runnable, " on ", threadPoolExecutor));
+		}
+	}
 
 	/**
 	 * Keep this as a static field to avoid the class loading failure during
 	 * Tomcat shutdown.
 	 */
 	private static final RejectedExecutionHandler _REJECTED_EXECUTION_HANDLER =
-		new RejectedExecutionHandler() {
-
-			@Override
-			public void rejectedExecution(
-				Runnable runnable, ThreadPoolExecutor threadPoolExecutor) {
-
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						StringBundler.concat(
-							"Discarded ", runnable, " on ",
-							threadPoolExecutor));
-				}
-			}
-
-		};
+		(runnable, threadPoolExecutor) -> _logRejectedExecution(
+			runnable, threadPoolExecutor);
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		EmbeddedElasticsearchConnection.class);
@@ -539,8 +412,24 @@ public class EmbeddedElasticsearchConnection
 	@Reference
 	private File _file;
 
+	private String _httpPort;
 	private Node _node;
 	private final Set<SettingsContributor> _settingsContributors =
 		new ConcurrentSkipListSet<>();
+
+	private class EmbeddedElasticsearchInstancePaths
+		implements ElasticsearchInstancePaths {
+
+		@Override
+		public Path getHomePath() {
+			return null;
+		}
+
+		@Override
+		public Path getWorkPath() {
+			return Paths.get(props.get(PropsKeys.LIFERAY_HOME));
+		}
+
+	}
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/RestHighLevelClientFactory.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/RestHighLevelClientFactory.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.connection;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.elasticsearch7.internal.util.ClassLoaderUtil;
+
+import java.io.IOException;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import org.apache.http.HttpHost;
+
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.core.MainResponse;
+
+/**
+ * @author André de Oliveira
+ */
+public class RestHighLevelClientFactory {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Optional<RestHighLevelClient> getRestHighLevelClientOptional() {
+		return IntStream.rangeClosed(
+			_portFrom, _portTo
+		).mapToObj(
+			this::newRestHighLevelClient
+		).filter(
+			this::isMatch
+		).findFirst();
+	}
+
+	public static class Builder {
+
+		public RestHighLevelClientFactory build() {
+			return new RestHighLevelClientFactory(_restHighLevelClientFactory);
+		}
+
+		public Builder clusterName(String clusterName) {
+			_restHighLevelClientFactory._clusterName = clusterName;
+
+			return this;
+		}
+
+		public Builder hostName(String hostName) {
+			_restHighLevelClientFactory._hostName = hostName;
+
+			return this;
+		}
+
+		public Builder nodeName(String nodeName) {
+			_restHighLevelClientFactory._nodeName = nodeName;
+
+			return this;
+		}
+
+		public Builder portRange(String portRange) {
+			int[] ports = getPorts(portRange);
+
+			_restHighLevelClientFactory._portFrom = ports[0];
+			_restHighLevelClientFactory._portTo = ports[1];
+
+			return this;
+		}
+
+		public Builder scheme(String scheme) {
+			_restHighLevelClientFactory._scheme = scheme;
+
+			return this;
+		}
+
+		protected int[] getPorts(String portRange) {
+			String[] split = StringUtil.split(portRange, CharPool.DASH);
+
+			if (split.length >= 2) {
+				return new int[] {
+					Integer.valueOf(split[0]), Integer.valueOf(split[1])
+				};
+			}
+
+			return new int[] {
+				Integer.valueOf(split[0]), Integer.valueOf(split[0])
+			};
+		}
+
+		private final RestHighLevelClientFactory _restHighLevelClientFactory =
+			new RestHighLevelClientFactory();
+
+	}
+
+	protected static boolean isClusterName(
+		String clusterName, MainResponse mainResponse) {
+
+		if (Validator.isBlank(clusterName)) {
+			return true;
+		}
+
+		if (Objects.equals(clusterName, mainResponse.getClusterName())) {
+			return true;
+		}
+
+		return false;
+	}
+
+	protected static boolean isNodeName(
+		String nodeName, MainResponse mainResponse) {
+
+		if (Validator.isBlank(nodeName)) {
+			return true;
+		}
+
+		if (Objects.equals(nodeName, mainResponse.getNodeName())) {
+			return true;
+		}
+
+		return false;
+	}
+
+	protected boolean isMatch(MainResponse mainResponse) {
+		if (Validator.isBlank(_clusterName) && Validator.isBlank(_nodeName)) {
+			return true;
+		}
+
+		if (!isClusterName(_clusterName, mainResponse)) {
+			return false;
+		}
+
+		if (!isNodeName(_nodeName, mainResponse)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	protected boolean isMatch(RestHighLevelClient restHighLevelClient) {
+		try {
+			MainResponse mainResponse = restHighLevelClient.info(
+				RequestOptions.DEFAULT);
+
+			if (isMatch(mainResponse)) {
+				return true;
+			}
+
+			return false;
+		}
+		catch (IOException ioException) {
+			return false;
+		}
+	}
+
+	protected RestHighLevelClient newRestHighLevelClient(int port) {
+		return ClassLoaderUtil.getWithContextClassLoader(
+			() -> new RestHighLevelClient(
+				RestClient.builder(new HttpHost(_hostName, port, _scheme))),
+			getClass());
+	}
+
+	private RestHighLevelClientFactory() {
+	}
+
+	private RestHighLevelClientFactory(
+		RestHighLevelClientFactory restHighLevelClientFactory) {
+
+		_clusterName = restHighLevelClientFactory._clusterName;
+		_hostName = restHighLevelClientFactory._hostName;
+		_nodeName = restHighLevelClientFactory._nodeName;
+		_portFrom = restHighLevelClientFactory._portFrom;
+		_portTo = restHighLevelClientFactory._portTo;
+		_scheme = restHighLevelClientFactory._scheme;
+	}
+
+	private String _clusterName;
+	private String _hostName;
+	private String _nodeName;
+	private int _portFrom;
+	private int _portTo;
+	private String _scheme;
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/SidecarElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/connection/SidecarElasticsearchConnection.java
@@ -14,12 +14,9 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.connection;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.search.elasticsearch7.internal.sidecar.Sidecar;
-import com.liferay.portal.search.elasticsearch7.internal.util.ClassLoaderUtil;
 
-import org.apache.http.HttpHost;
-
-import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 
 /**
@@ -63,11 +60,20 @@ public class SidecarElasticsearchConnection
 
 	@Override
 	protected RestHighLevelClient createRestHighLevelClient() {
-		return ClassLoaderUtil.getWithContextClassLoader(
-			() -> new RestHighLevelClient(
-				RestClient.builder(
-					HttpHost.create(_sidecar.getNetworkHostAddress()))),
-			getClass());
+		return RestHighLevelClientFactory.builder(
+		).hostName(
+			"localhost"
+		).portRange(
+			getHttpPort(_sidecar.getNetworkHostAddress())
+		).scheme(
+			"http"
+		).build(
+		).getRestHighLevelClientOptional(
+		).get();
+	}
+
+	protected String getHttpPort(String address) {
+		return address.substring(address.indexOf(CharPool.COLON) + 1);
 	}
 
 	private final Sidecar _sidecar;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformation.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformation.java
@@ -21,13 +21,13 @@ import com.liferay.portal.search.index.IndexNameBuilder;
 
 import java.io.IOException;
 
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.client.indices.GetIndexResponse;
 import org.elasticsearch.common.Strings;
 
 import org.osgi.service.component.annotations.Component;
@@ -41,7 +41,7 @@ public class ElasticsearchIndexInformation implements IndexInformation {
 
 	@Override
 	public String getCompanyIndexName(long companyId) {
-		return indexNameBuilder.getIndexName(companyId);
+		return _indexNameBuilder.getIndexName(companyId);
 	}
 
 	@Override
@@ -58,9 +58,7 @@ public class ElasticsearchIndexInformation implements IndexInformation {
 
 	@Override
 	public String[] getIndexNames() {
-		GetIndexRequest getIndexRequest = new GetIndexRequest();
-
-		getIndexRequest.indices(StringPool.STAR);
+		GetIndexRequest getIndexRequest = new GetIndexRequest(StringPool.STAR);
 
 		GetIndexResponse getIndexResponse = getIndexResponse(getIndexRequest);
 
@@ -82,7 +80,7 @@ public class ElasticsearchIndexInformation implements IndexInformation {
 
 	protected IndicesClient getIndicesClient() {
 		RestHighLevelClient restHighLevelClient =
-			elasticsearchClientResolver.getRestHighLevelClient(null, true);
+			_elasticsearchClientResolver.getRestHighLevelClient(null, true);
 
 		return restHighLevelClient.indices();
 	}
@@ -101,10 +99,19 @@ public class ElasticsearchIndexInformation implements IndexInformation {
 		}
 	}
 
-	@Reference
-	protected ElasticsearchClientResolver elasticsearchClientResolver;
+	@Reference(unbind = "-")
+	protected void setElasticsearchClientResolver(
+		ElasticsearchClientResolver elasticsearchClientResolver) {
 
-	@Reference
-	protected IndexNameBuilder indexNameBuilder;
+		_elasticsearchClientResolver = elasticsearchClientResolver;
+	}
+
+	@Reference(unbind = "-")
+	protected void setIndexNameBuilder(IndexNameBuilder indexNameBuilder) {
+		_indexNameBuilder = indexNameBuilder;
+	}
+
+	private ElasticsearchClientResolver _elasticsearchClientResolver;
+	private IndexNameBuilder _indexNameBuilder;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayDocumentTypeFactory.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayDocumentTypeFactory.java
@@ -33,13 +33,12 @@ import java.util.Map;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
-import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
+import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -65,8 +64,6 @@ public class LiferayDocumentTypeFactory implements TypeMappingsHelper {
 				source, indexName,
 				LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE),
 			XContentType.JSON);
-		putMappingRequest.type(
-			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		try {
 			ActionResponse actionResponse = _indicesClient.putMapping(
@@ -133,7 +130,6 @@ public class LiferayDocumentTypeFactory implements TypeMappingsHelper {
 		GetMappingsRequest getMappingsRequest = new GetMappingsRequest();
 
 		getMappingsRequest.indices(indexName);
-		getMappingsRequest.types(typeName);
 
 		GetMappingsResponse getMappingsResponse = null;
 
@@ -145,12 +141,9 @@ public class LiferayDocumentTypeFactory implements TypeMappingsHelper {
 			throw new RuntimeException(ioException);
 		}
 
-		ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>>
-			map = getMappingsResponse.mappings();
+		Map<String, MappingMetaData> mappings = getMappingsResponse.mappings();
 
-		ImmutableOpenMap<String, MappingMetaData> mappings = map.get(indexName);
-
-		MappingMetaData mappingMetaData = mappings.get(typeName);
+		MappingMetaData mappingMetaData = mappings.get(indexName);
 
 		CompressedXContent compressedXContent = mappingMetaData.source();
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/GetMappingIndexRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/GetMappingIndexRequestExecutorImpl.java
@@ -23,13 +23,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.compress.CompressedXContent;
 
 import org.osgi.service.component.annotations.Component;
@@ -52,17 +51,12 @@ public class GetMappingIndexRequestExecutorImpl
 		GetMappingsResponse getMappingsResponse = getGetMappingsResponse(
 			getMappingsRequest, getMappingIndexRequest);
 
-		ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>>
-			mappings = getMappingsResponse.mappings();
+		Map<String, MappingMetaData> mappings = getMappingsResponse.mappings();
 
 		Map<String, String> indexMappings = new HashMap<>();
 
 		for (String indexName : getMappingIndexRequest.getIndexNames()) {
-			ImmutableOpenMap<String, MappingMetaData> indexMapping =
-				mappings.get(indexName);
-
-			MappingMetaData mappingMetaData = indexMapping.get(
-				getMappingIndexRequest.getMappingName());
+			MappingMetaData mappingMetaData = mappings.get(indexName);
 
 			CompressedXContent mappingContent = mappingMetaData.source();
 
@@ -78,7 +72,6 @@ public class GetMappingIndexRequestExecutorImpl
 		GetMappingsRequest getMappingsRequest = new GetMappingsRequest();
 
 		getMappingsRequest.indices(getMappingIndexRequest.getIndexNames());
-		getMappingsRequest.types(getMappingIndexRequest.getMappingName());
 
 		return getMappingsRequest;
 	}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/ClassModificationUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/ClassModificationUtil.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.sidecar;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.function.Consumer;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * @author Tina Tian
+ * @author André de Oliveira
+ */
+public class ClassModificationUtil {
+
+	public static byte[] getModifiedClassBytes(
+			String className, String methodName,
+			Consumer<MethodVisitor> methodVisitorConsumer,
+			ClassLoader classLoader)
+		throws ClassNotFoundException, IOException {
+
+		Class<?> clazz = classLoader.loadClass(className);
+
+		try (InputStream inputStream = clazz.getResourceAsStream(
+				clazz.getSimpleName() + ".class")) {
+
+			ClassReader classReader = new ClassReader(inputStream);
+
+			ClassWriter classWriter = new ClassWriter(
+				classReader, ClassWriter.COMPUTE_MAXS);
+
+			classReader.accept(
+				new ClassVisitor(Opcodes.ASM5, classWriter) {
+
+					@Override
+					public MethodVisitor visitMethod(
+						int access, String name, String description,
+						String signature, String[] exceptions) {
+
+						MethodVisitor methodVisitor = super.visitMethod(
+							access, name, description, signature, exceptions);
+
+						if (!name.equals(methodName)) {
+							return methodVisitor;
+						}
+
+						return new MethodVisitor(Opcodes.ASM5) {
+
+							@Override
+							public void visitCode() {
+								methodVisitorConsumer.accept(methodVisitor);
+							}
+
+							@Override
+							public void visitMaxs(int maxStack, int maxLocals) {
+								methodVisitor.visitMaxs(0, 0);
+							}
+
+						};
+					}
+
+				},
+				0);
+
+			return classWriter.toByteArray();
+		}
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/PathUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/PathUtil.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.sidecar;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.io.IOException;
+
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+/**
+ * @author Tina Tian
+ * @author André de Oliveira
+ */
+public class PathUtil {
+
+	public static void deleteDir(Path dirPath) {
+		if (dirPath == null) {
+			return;
+		}
+
+		try {
+			Files.walkFileTree(
+				dirPath,
+				new SimpleFileVisitor<Path>() {
+
+					@Override
+					public FileVisitResult postVisitDirectory(
+							Path path, IOException ioException)
+						throws IOException {
+
+						if (ioException != null) {
+							throw ioException;
+						}
+
+						Files.delete(path);
+
+						return FileVisitResult.CONTINUE;
+					}
+
+					@Override
+					public FileVisitResult visitFile(
+							Path path, BasicFileAttributes basicFileAttributes)
+						throws IOException {
+
+						Files.delete(path);
+
+						return FileVisitResult.CONTINUE;
+					}
+
+					@Override
+					public FileVisitResult visitFileFailed(
+							Path path, IOException ioException)
+						throws IOException {
+
+						if (ioException instanceof NoSuchFileException) {
+							return FileVisitResult.CONTINUE;
+						}
+
+						throw ioException;
+					}
+
+				});
+		}
+		catch (IOException ioException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to delete " + dirPath, ioException);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(PathUtil.class);
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/ProcessExecutorPaths.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/ProcessExecutorPaths.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.sidecar;
+
+import java.nio.file.Path;
+
+/**
+ * @author André de Oliveira
+ */
+public interface ProcessExecutorPaths {
+
+	public Path getLibPath();
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/ProcessExecutorPathsImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/ProcessExecutorPathsImpl.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.sidecar;
+
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * @author André de Oliveira
+ */
+public class ProcessExecutorPathsImpl implements ProcessExecutorPaths {
+
+	public ProcessExecutorPathsImpl(Props props) {
+		_props = props;
+	}
+
+	@Override
+	public Path getLibPath() {
+		return Paths.get(_props.get(PropsKeys.LIFERAY_LIB_GLOBAL_DIR));
+	}
+
+	private final Props _props;
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexingFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexingFixture.java
@@ -55,7 +55,7 @@ public class ElasticsearchIndexingFixture implements IndexingFixture {
 		return _companyId;
 	}
 
-	public ElasticsearchFixture getElasticsearchFixture() {
+	public ElasticsearchClientResolver getElasticsearchClientResolver() {
 		return _elasticsearchFixture;
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineReconnectTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchSearchEngineReconnectTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnection;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionManager;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.SnapshotClient;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author André de Oliveira
+ */
+public class ElasticsearchSearchEngineReconnectTest {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+			ElasticsearchConnectionFixture.builder(
+			).clusterName(
+				ElasticsearchSearchEngineReconnectTest.class.getSimpleName()
+			).build();
+
+		ElasticsearchSearchEngineFixture elasticsearchSearchEngineFixture =
+			new ElasticsearchSearchEngineFixture(
+				elasticsearchConnectionFixture);
+
+		elasticsearchSearchEngineFixture.setUp();
+
+		_elasticsearchConnectionFixture = elasticsearchConnectionFixture;
+
+		_elasticsearchSearchEngineFixture = elasticsearchSearchEngineFixture;
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_elasticsearchSearchEngineFixture.tearDown();
+	}
+
+	public SnapshotClient getSnapshotClient() {
+		RestHighLevelClient restHighLevelClient =
+			_elasticsearchConnectionFixture.getRestHighLevelClient();
+
+		return restHighLevelClient.snapshot();
+	}
+
+	@Test
+	public void testInitializeAfterReconnect() {
+		ElasticsearchSearchEngine elasticsearchSearchEngine =
+			_elasticsearchSearchEngineFixture.getElasticsearchSearchEngine();
+
+		long companyId = RandomTestUtil.randomLong();
+
+		elasticsearchSearchEngine.initialize(companyId);
+
+		reconnect(
+			_elasticsearchSearchEngineFixture.
+				getElasticsearchConnectionManager());
+
+		elasticsearchSearchEngine.initialize(companyId);
+	}
+
+	protected void reconnect(
+		ElasticsearchConnectionManager elasticsearchConnectionManager) {
+
+		ElasticsearchConnection elasticsearchConnection =
+			elasticsearchConnectionManager.getElasticsearchConnection();
+
+		elasticsearchConnection.close();
+
+		elasticsearchConnection.connect();
+	}
+
+	private static ElasticsearchConnectionFixture
+		_elasticsearchConnectionFixture;
+	private static ElasticsearchSearchEngineFixture
+		_elasticsearchSearchEngineFixture;
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutorTest.java
@@ -15,7 +15,7 @@
 package com.liferay.portal.search.elasticsearch7.internal.background.task;
 
 import com.liferay.portal.search.elasticsearch7.internal.ElasticsearchSearchEngineFixture;
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch7.internal.index.FieldMappingAssert;
 import com.liferay.portal.search.elasticsearch7.internal.index.LiferayTypeMappingsConstants;
 import com.liferay.portal.search.test.util.background.task.BaseReindexSingleIndexerBackgroundTaskExecutorTestCase;
@@ -28,15 +28,29 @@ import org.elasticsearch.client.RestHighLevelClient;
 public class ReindexSingleIndexerBackgroundTaskExecutorTest
 	extends BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
 
+	public ReindexSingleIndexerBackgroundTaskExecutorTest() {
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+			ElasticsearchConnectionFixture.builder(
+			).clusterName(
+				ReindexSingleIndexerBackgroundTaskExecutorTest.class.
+					getSimpleName()
+			).build();
+
+		ElasticsearchSearchEngineFixture elasticsearchSearchEngineFixture =
+			new ElasticsearchSearchEngineFixture(
+				elasticsearchConnectionFixture);
+
+		_elasticsearchConnectionFixture = elasticsearchConnectionFixture;
+
+		_elasticsearchSearchEngineFixture = elasticsearchSearchEngineFixture;
+	}
+
 	@Override
 	protected void assertFieldType(String fieldName, String fieldType)
 		throws Exception {
 
-		ElasticsearchFixture elasticsearchFixture =
-			_elasticsearchSearchEngineFixture.getElasticsearchFixture();
-
 		RestHighLevelClient restHighLevelClient =
-			elasticsearchFixture.getRestHighLevelClient();
+			_elasticsearchConnectionFixture.getRestHighLevelClient();
 
 		FieldMappingAssert.assertType(
 			fieldType, fieldName,
@@ -44,23 +58,14 @@ public class ReindexSingleIndexerBackgroundTaskExecutorTest
 			restHighLevelClient.indices());
 	}
 
-	protected RestHighLevelClient getRestHighLevelClient() {
-		ElasticsearchFixture elasticsearchFixture =
-			_elasticsearchSearchEngineFixture.getElasticsearchFixture();
-
-		return elasticsearchFixture.getRestHighLevelClient();
-	}
-
 	@Override
 	protected ElasticsearchSearchEngineFixture getSearchEngineFixture() {
-		_elasticsearchSearchEngineFixture =
-			new ElasticsearchSearchEngineFixture(
-				ReindexSingleIndexerBackgroundTaskExecutorTest.class.
-					getSimpleName());
-
 		return _elasticsearchSearchEngineFixture;
 	}
 
-	private ElasticsearchSearchEngineFixture _elasticsearchSearchEngineFixture;
+	private final ElasticsearchConnectionFixture
+		_elasticsearchConnectionFixture;
+	private final ElasticsearchSearchEngineFixture
+		_elasticsearchSearchEngineFixture;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/cluster/Cluster1InstanceTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/cluster/Cluster1InstanceTest.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.cluster;
 
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch7.internal.connection.Index;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexCreator;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
@@ -42,20 +42,23 @@ public class Cluster1InstanceTest {
 
 	@Test
 	public void test1PrimaryShardByDefault() throws Exception {
-		ElasticsearchFixture elasticsearchFixture = _testCluster.getNode(0);
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+			_testCluster.getNode(0);
 
-		createIndex(elasticsearchFixture);
+		createIndex(elasticsearchConnectionFixture);
 
-		ClusterAssert.assert1PrimaryShardOnly(elasticsearchFixture);
+		ClusterAssert.assert1PrimaryShardOnly(elasticsearchConnectionFixture);
 	}
 
 	@Rule
 	public TestName testName = new TestName();
 
-	protected Index createIndex(ElasticsearchFixture elasticsearchFixture) {
+	protected Index createIndex(
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture) {
+
 		IndexCreator indexCreator = new IndexCreator() {
 			{
-				setElasticsearchClientResolver(elasticsearchFixture);
+				setElasticsearchClientResolver(elasticsearchConnectionFixture);
 			}
 		};
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/cluster/Cluster2InstancesTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/cluster/Cluster2InstancesTest.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.cluster;
 
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch7.internal.connection.Index;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexCreator;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
@@ -22,8 +22,8 @@ import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
 import org.elasticsearch.client.RestHighLevelClient;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -31,11 +31,12 @@ import org.junit.rules.TestName;
 /**
  * @author André de Oliveira
  */
-@Ignore
 public class Cluster2InstancesTest {
 
 	@Before
 	public void setUp() throws Exception {
+		Assume.assumeTrue(ClusterAssert.isClusterTestingEnabled());
+
 		_testCluster.setUp();
 	}
 
@@ -46,47 +47,57 @@ public class Cluster2InstancesTest {
 
 	@Test
 	public void test2Nodes1PrimaryShard() throws Exception {
-		ElasticsearchFixture elasticsearchFixture0 = _testCluster.getNode(0);
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture0 =
+			_testCluster.getNode(0);
 
-		createIndex(elasticsearchFixture0);
+		createIndex(elasticsearchConnectionFixture0);
 
-		ClusterAssert.assert1PrimaryShardAnd2Nodes(elasticsearchFixture0);
+		ClusterAssert.assert1PrimaryShardAnd2Nodes(
+			elasticsearchConnectionFixture0);
 
-		ElasticsearchFixture elasticsearchFixture1 = _testCluster.getNode(1);
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture1 =
+			_testCluster.getNode(1);
 
-		createIndex(elasticsearchFixture1);
+		createIndex(elasticsearchConnectionFixture1);
 
-		ClusterAssert.assert1PrimaryShardAnd2Nodes(elasticsearchFixture1);
+		ClusterAssert.assert1PrimaryShardAnd2Nodes(
+			elasticsearchConnectionFixture1);
 	}
 
 	@Test
 	public void testExpandAndShrink() throws Exception {
-		ElasticsearchFixture elasticsearchFixture0 = _testCluster.getNode(0);
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture0 =
+			_testCluster.getNode(0);
 
-		Index index0 = createIndex(elasticsearchFixture0);
+		Index index0 = createIndex(elasticsearchConnectionFixture0);
 
-		ElasticsearchFixture elasticsearchFixture1 = _testCluster.getNode(1);
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture1 =
+			_testCluster.getNode(1);
 
-		Index index1 = createIndex(elasticsearchFixture1);
+		Index index1 = createIndex(elasticsearchConnectionFixture1);
 
-		updateNumberOfReplicas(1, index1, elasticsearchFixture1);
+		updateNumberOfReplicas(1, index1, elasticsearchConnectionFixture1);
 
-		ClusterAssert.assert1ReplicaShard(elasticsearchFixture0);
-		ClusterAssert.assert1ReplicaShard(elasticsearchFixture1);
+		ClusterAssert.assert1ReplicaShard(elasticsearchConnectionFixture0);
+		ClusterAssert.assert1ReplicaShard(elasticsearchConnectionFixture1);
 
-		updateNumberOfReplicas(0, index0, elasticsearchFixture0);
+		updateNumberOfReplicas(0, index0, elasticsearchConnectionFixture0);
 
-		ClusterAssert.assert1PrimaryShardAnd2Nodes(elasticsearchFixture0);
-		ClusterAssert.assert1PrimaryShardAnd2Nodes(elasticsearchFixture1);
+		ClusterAssert.assert1PrimaryShardAnd2Nodes(
+			elasticsearchConnectionFixture0);
+		ClusterAssert.assert1PrimaryShardAnd2Nodes(
+			elasticsearchConnectionFixture1);
 	}
 
 	@Rule
 	public TestName testName = new TestName();
 
-	protected Index createIndex(ElasticsearchFixture elasticsearchFixture) {
+	protected Index createIndex(
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture) {
+
 		IndexCreator indexCreator = new IndexCreator() {
 			{
-				setElasticsearchClientResolver(elasticsearchFixture);
+				setElasticsearchClientResolver(elasticsearchConnectionFixture);
 			}
 		};
 
@@ -96,10 +107,10 @@ public class Cluster2InstancesTest {
 
 	protected void updateNumberOfReplicas(
 		int numberOfReplicas, Index index,
-		ElasticsearchFixture elasticsearchFixture) {
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture) {
 
 		RestHighLevelClient restHighLevelClient =
-			elasticsearchFixture.getRestHighLevelClient();
+			elasticsearchConnectionFixture.getRestHighLevelClient();
 
 		ReplicasManager replicasManager = new ReplicasManagerImpl(
 			restHighLevelClient.indices());

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/cluster/ClusterAssert.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/cluster/ClusterAssert.java
@@ -14,11 +14,11 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.cluster;
 
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ClusterHealthResponseUtil;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchClientResolver;
 import com.liferay.portal.search.elasticsearch7.internal.connection.HealthExpectations;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -32,11 +32,11 @@ import org.junit.Assert;
 public class ClusterAssert {
 
 	public static void assert1PrimaryAnd1UnassignedShard(
-			ElasticsearchFixture elasticsearchFixture)
+			ElasticsearchClientResolver elasticsearchClientResolver)
 		throws Exception {
 
 		assertHealth(
-			elasticsearchFixture,
+			elasticsearchClientResolver,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(1);
@@ -50,11 +50,11 @@ public class ClusterAssert {
 	}
 
 	public static void assert1PrimaryShardAnd2Nodes(
-			ElasticsearchFixture elasticsearchFixture)
+			ElasticsearchClientResolver elasticsearchClientResolver)
 		throws Exception {
 
 		assertHealth(
-			elasticsearchFixture,
+			elasticsearchClientResolver,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(1);
@@ -68,11 +68,11 @@ public class ClusterAssert {
 	}
 
 	public static void assert1PrimaryShardOnly(
-			ElasticsearchFixture elasticsearchFixture)
+			ElasticsearchClientResolver elasticsearchClientResolver)
 		throws Exception {
 
 		assertHealth(
-			elasticsearchFixture,
+			elasticsearchClientResolver,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(1);
@@ -86,11 +86,11 @@ public class ClusterAssert {
 	}
 
 	public static void assert1ReplicaAnd1UnassignedShard(
-			ElasticsearchFixture elasticsearchFixture)
+			ElasticsearchClientResolver elasticsearchClientResolver)
 		throws Exception {
 
 		assertHealth(
-			elasticsearchFixture,
+			elasticsearchClientResolver,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(1);
@@ -104,11 +104,11 @@ public class ClusterAssert {
 	}
 
 	public static void assert1ReplicaShard(
-			ElasticsearchFixture elasticsearchFixture)
+			ElasticsearchClientResolver elasticsearchClientResolver)
 		throws Exception {
 
 		assertHealth(
-			elasticsearchFixture,
+			elasticsearchClientResolver,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(1);
@@ -122,11 +122,11 @@ public class ClusterAssert {
 	}
 
 	public static void assert2Primary2UnassignedShardsAnd1Node(
-			ElasticsearchFixture elasticsearchFixture)
+			ElasticsearchClientResolver elasticsearchClientResolver)
 		throws Exception {
 
 		assertHealth(
-			elasticsearchFixture,
+			elasticsearchClientResolver,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(2);
@@ -140,11 +140,11 @@ public class ClusterAssert {
 	}
 
 	public static void assert2PrimaryShards1ReplicaAnd2Nodes(
-			ElasticsearchFixture elasticsearchFixture)
+			ElasticsearchClientResolver elasticsearchClientResolver)
 		throws Exception {
 
 		assertHealth(
-			elasticsearchFixture,
+			elasticsearchClientResolver,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(2);
@@ -158,11 +158,11 @@ public class ClusterAssert {
 	}
 
 	public static void assert2PrimaryShardsAnd2Nodes(
-			ElasticsearchFixture elasticsearchFixture)
+			ElasticsearchClientResolver elasticsearchClientResolver)
 		throws Exception {
 
 		assertHealth(
-			elasticsearchFixture,
+			elasticsearchClientResolver,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(2);
@@ -176,11 +176,11 @@ public class ClusterAssert {
 	}
 
 	public static void assert2ReplicaShards(
-			ElasticsearchFixture elasticsearchFixture)
+			ElasticsearchClientResolver elasticsearchClientResolver)
 		throws Exception {
 
 		assertHealth(
-			elasticsearchFixture,
+			elasticsearchClientResolver,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(1);
@@ -194,25 +194,24 @@ public class ClusterAssert {
 	}
 
 	public static void assertHealth(
-			final ElasticsearchFixture elasticsearchFixture,
+			final ElasticsearchClientResolver elasticsearchClientResolver,
 			final HealthExpectations healthExpectations)
 		throws Exception {
 
 		IdempotentRetryAssert.retryAssert(
 			10, TimeUnit.MINUTES,
-			new Callable<Void>() {
+			() -> {
+				_assertHealth(
+					ClusterHealthResponseUtil.getClusterHealthResponse(
+						elasticsearchClientResolver, healthExpectations),
+					healthExpectations);
 
-				@Override
-				public Void call() throws Exception {
-					_assertHealth(
-						elasticsearchFixture.getClusterHealthResponse(
-							healthExpectations),
-						healthExpectations);
-
-					return null;
-				}
-
+				return null;
 			});
+	}
+
+	public static boolean isClusterTestingEnabled() {
+		return false;
 	}
 
 	private static void _assertHealth(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/cluster/TestCluster.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/cluster/TestCluster.java
@@ -16,7 +16,7 @@ package com.liferay.portal.search.elasticsearch7.internal.cluster;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -33,35 +33,37 @@ public class TestCluster {
 	public TestCluster(int size, Object object) {
 		String prefix = getPrefix(object);
 
-		_elasticsearchConfigurationProperties =
-			createElasticsearchConfigurationProperties(prefix, size);
-
-		_elasticsearchFixtures = new ElasticsearchFixture[size];
+		_elasticsearchFixtures = new ElasticsearchConnectionFixture[size];
 
 		_prefix = prefix;
 	}
 
-	public ElasticsearchFixture createNode(int index) throws Exception {
-		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
-			_prefix + "-" + index, _elasticsearchConfigurationProperties);
+	public ElasticsearchConnectionFixture createNode(int index) {
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+			ElasticsearchConnectionFixture.builder(
+			).clusterName(
+				_prefix + "-" + index
+			).clusterSettingsContext(
+				new TestClusterSettingsContext()
+			).elasticsearchConfigurationProperties(
+				createElasticsearchConfigurationProperties(
+					index, _prefix, _elasticsearchFixtures.length)
+			).build();
 
-		elasticsearchFixture.setClusterSettingsContext(
-			new TestClusterSettingsContext());
+		elasticsearchConnectionFixture.createNode();
 
-		elasticsearchFixture.createNode();
+		_elasticsearchFixtures[index] = elasticsearchConnectionFixture;
 
-		_elasticsearchFixtures[index] = elasticsearchFixture;
-
-		return elasticsearchFixture;
+		return elasticsearchConnectionFixture;
 	}
 
-	public void createNodes() throws Exception {
+	public void createNodes() {
 		for (int i = 0; i < _elasticsearchFixtures.length; i++) {
 			createNode(i);
 		}
 	}
 
-	public void destroyNode(int index) throws Exception {
+	public void destroyNode(int index) {
 		if (_elasticsearchFixtures[index] != null) {
 			_elasticsearchFixtures[index].destroyNode();
 
@@ -69,44 +71,48 @@ public class TestCluster {
 		}
 	}
 
-	public void destroyNodes() throws Exception {
+	public void destroyNodes() {
 		for (int i = 0; i < _elasticsearchFixtures.length; i++) {
 			destroyNode(i);
 		}
 	}
 
-	public ElasticsearchFixture getNode(int index) {
+	public ElasticsearchConnectionFixture getNode(int index) {
 		return _elasticsearchFixtures[index];
 	}
 
-	public void setUp() throws Exception {
+	public void setUp() {
 		createNodes();
 	}
 
-	public void tearDown() throws Exception {
+	public void tearDown() {
 		destroyNodes();
 	}
 
 	protected HashMap<String, Object>
-		createElasticsearchConfigurationProperties(String prefix, int size) {
+		createElasticsearchConfigurationProperties(
+			int index, String prefix, int size) {
 
-		int startingPort = 9310;
-
-		String range = String.valueOf(startingPort);
-
-		if (size > 1) {
-			int endingPort = startingPort + size - 1;
-
-			range = range + StringPool.MINUS + endingPort;
-		}
+		String transportRange = getPortRange(9310, size);
 
 		return HashMapBuilder.<String, Object>put(
 			"clusterName", prefix + "-Cluster"
 		).put(
-			"discoveryZenPingUnicastHostsPort", range
+			"discoveryZenPingUnicastHostsPort", transportRange
 		).put(
-			"transportTcpPort", range
+			"embeddedHttpPort", String.valueOf(9202 + index)
+		).put(
+			"transportTcpPort", transportRange
 		).build();
+	}
+
+	protected String getPortRange(int startingPort, int size) {
+		if (size > 1) {
+			return String.valueOf(startingPort) + StringPool.MINUS +
+				String.valueOf(startingPort + size - 1);
+		}
+
+		return String.valueOf(startingPort);
 	}
 
 	protected String getPrefix(Object object) {
@@ -115,8 +121,7 @@ public class TestCluster {
 		return clazz.getSimpleName();
 	}
 
-	private final HashMap<String, Object> _elasticsearchConfigurationProperties;
-	private final ElasticsearchFixture[] _elasticsearchFixtures;
+	private final ElasticsearchConnectionFixture[] _elasticsearchFixtures;
 	private final String _prefix;
 
 	private static class TestClusterSettingsContext

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/configuration/ElasticsearchConfigurationTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/configuration/ElasticsearchConfigurationTest.java
@@ -15,7 +15,7 @@
 package com.liferay.portal.search.elasticsearch7.internal.configuration;
 
 import com.liferay.portal.kernel.util.PropertiesUtil;
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 
 import java.util.Map;
 import java.util.Properties;
@@ -33,16 +33,19 @@ public class ElasticsearchConfigurationTest {
 			loadConfigurationProperties(
 				"ElasticsearchConfigurationTest-build-test-xml.cfg");
 
-		Class<? extends ElasticsearchConfigurationTest> clazz = getClass();
-
-		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
-			clazz.getSimpleName(), configurationProperties);
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+			ElasticsearchConnectionFixture.builder(
+			).clusterName(
+				ElasticsearchConfigurationTest.class.getSimpleName()
+			).elasticsearchConfigurationProperties(
+				configurationProperties
+			).build();
 
 		try {
-			elasticsearchFixture.createNode();
+			elasticsearchConnectionFixture.createNode();
 		}
 		finally {
-			elasticsearchFixture.destroyNode();
+			elasticsearchConnectionFixture.destroyNode();
 		}
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ClusterHealthResponseUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ClusterHealthResponseUtil.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.connection;
+
+import java.io.IOException;
+
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.client.ClusterClient;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.TimeValue;
+
+/**
+ * @author André de Oliveira
+ */
+public class ClusterHealthResponseUtil {
+
+	public static ClusterHealthResponse getClusterHealthResponse(
+		ElasticsearchClientResolver elasticsearchClientResolver,
+		HealthExpectations healthExpectations) {
+
+		RestHighLevelClient restHighLevelClient =
+			elasticsearchClientResolver.getRestHighLevelClient();
+
+		ClusterClient clusterClient = restHighLevelClient.cluster();
+
+		ClusterHealthRequest clusterHealthRequest = new ClusterHealthRequest();
+
+		clusterHealthRequest.timeout(new TimeValue(10, TimeUnit.MINUTES));
+		clusterHealthRequest.waitForActiveShards(
+			healthExpectations.getActiveShards());
+		clusterHealthRequest.waitForNodes(
+			String.valueOf(healthExpectations.getNumberOfNodes()));
+		clusterHealthRequest.waitForNoRelocatingShards(true);
+		clusterHealthRequest.waitForStatus(healthExpectations.getStatus());
+
+		try {
+			return clusterClient.health(
+				clusterHealthRequest, RequestOptions.DEFAULT);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchConnectionFixture.java
@@ -1,0 +1,351 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch7.internal.connection;
+
+import com.liferay.petra.process.local.LocalProcessExecutor;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.SystemProperties;
+import com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration;
+import com.liferay.portal.search.elasticsearch7.internal.cluster.ClusterSettingsContext;
+import com.liferay.portal.search.elasticsearch7.internal.cluster.UnicastSettingsContributor;
+import com.liferay.portal.search.elasticsearch7.internal.settings.BaseSettingsContributor;
+import com.liferay.portal.search.elasticsearch7.internal.sidecar.PathUtil;
+import com.liferay.portal.search.elasticsearch7.internal.sidecar.Sidecar;
+import com.liferay.portal.search.elasticsearch7.settings.ClientSettingsHelper;
+import com.liferay.portal.search.elasticsearch7.settings.SettingsContributor;
+import com.liferay.portal.util.FileImpl;
+
+import java.io.File;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.elasticsearch.client.RestHighLevelClient;
+
+import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+
+/**
+ * @author André de Oliveira
+ */
+public class ElasticsearchConnectionFixture
+	implements ElasticsearchClientResolver {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public void createNode() {
+		deleteTmpDir();
+
+		_elasticsearchConnection = openElasticsearchConnection();
+	}
+
+	public void destroyNode() {
+		if (_elasticsearchConnection != null) {
+			_elasticsearchConnection.close();
+		}
+
+		deleteTmpDir();
+	}
+
+	public Map<String, Object> getElasticsearchConfigurationProperties() {
+		return _elasticsearchConfigurationProperties;
+	}
+
+	public ElasticsearchConnection getElasticsearchConnection() {
+		return _elasticsearchConnection;
+	}
+
+	@Override
+	public RestHighLevelClient getRestHighLevelClient() {
+		return _elasticsearchConnection.getRestHighLevelClient();
+	}
+
+	@Override
+	public RestHighLevelClient getRestHighLevelClient(String connectionId) {
+		return getRestHighLevelClient();
+	}
+
+	@Override
+	public RestHighLevelClient getRestHighLevelClient(
+		String connectionId, boolean preferLocalCluster) {
+
+		return getRestHighLevelClient();
+	}
+
+	public static class Builder {
+
+		public ElasticsearchConnectionFixture build() {
+			ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+				new ElasticsearchConnectionFixture();
+
+			elasticsearchConnectionFixture._clusterSettingsContext =
+				_clusterSettingsContext;
+			elasticsearchConnectionFixture.
+				_elasticsearchConfigurationProperties =
+					createElasticsearchConfigurationProperties(
+						_elasticsearchConfigurationProperties, _clusterName);
+			elasticsearchConnectionFixture._workPath = _TMP_PATH.resolve(
+				_clusterName);
+
+			return elasticsearchConnectionFixture;
+		}
+
+		public ElasticsearchConnectionFixture.Builder clusterName(
+			String clusterName) {
+
+			_clusterName = clusterName;
+
+			return this;
+		}
+
+		public Builder clusterSettingsContext(
+			ClusterSettingsContext clusterSettingsContext) {
+
+			_clusterSettingsContext = clusterSettingsContext;
+
+			return this;
+		}
+
+		public Builder elasticsearchConfigurationProperties(
+			Map<String, Object> elasticsearchConfigurationProperties) {
+
+			if (elasticsearchConfigurationProperties == null) {
+				elasticsearchConfigurationProperties =
+					Collections.<String, Object>emptyMap();
+			}
+
+			_elasticsearchConfigurationProperties =
+				elasticsearchConfigurationProperties;
+
+			return this;
+		}
+
+		protected static final Map<String, Object>
+			createElasticsearchConfigurationProperties(
+				Map<String, Object> elasticsearchConfigurationProperties,
+				String clusterName) {
+
+			return HashMapBuilder.<String, Object>put(
+				"clusterName", clusterName
+			).put(
+				"configurationPid", ElasticsearchConfiguration.class.getName()
+			).put(
+				"httpCORSAllowOrigin", "*"
+			).put(
+				"logExceptionsOnly", false
+			).put(
+				"sidecarHttpPort", "9200-9300"
+			).putAll(
+				elasticsearchConfigurationProperties
+			).build();
+		}
+
+		private String _clusterName;
+		private ClusterSettingsContext _clusterSettingsContext;
+		private Map<String, Object> _elasticsearchConfigurationProperties =
+			Collections.<String, Object>emptyMap();
+
+	}
+
+	protected ElasticsearchConnection createElasticsearchConnection() {
+		if (_SIDECAR_REPLACES_EMBEDDED) {
+			return createSidecarElasticsearchConnection();
+		}
+
+		return createEmbeddedElasticsearchConnection();
+	}
+
+	protected ElasticsearchInstancePaths createElasticsearchInstancePaths() {
+		ElasticsearchInstancePaths elasticsearchInstancePaths = Mockito.mock(
+			ElasticsearchInstancePaths.class);
+
+		Mockito.doReturn(
+			_TMP_PATH.resolve("sidecar-elasticsearch")
+		).when(
+			elasticsearchInstancePaths
+		).getHomePath();
+
+		Mockito.doReturn(
+			_workPath
+		).when(
+			elasticsearchInstancePaths
+		).getWorkPath();
+
+		return elasticsearchInstancePaths;
+	}
+
+	protected ElasticsearchConnection createEmbeddedElasticsearchConnection() {
+		EmbeddedElasticsearchConnection embeddedElasticsearchConnection =
+			new EmbeddedElasticsearchConnection();
+
+		List<SettingsContributor> settingsContributors =
+			getSettingsContributors();
+
+		settingsContributors.forEach(
+			embeddedElasticsearchConnection::addSettingsContributor);
+
+		embeddedElasticsearchConnection.clusterSettingsContext =
+			getClusterSettingsContext();
+
+		embeddedElasticsearchConnection.props = createProps();
+
+		ReflectionTestUtil.setFieldValue(
+			embeddedElasticsearchConnection, "_file", new FileImpl());
+
+		BundleContext bundleContext = Mockito.mock(BundleContext.class);
+
+		Mockito.when(
+			bundleContext.getDataFile(
+				EmbeddedElasticsearchConnection.JNA_TMP_DIR)
+		).thenReturn(
+			new File(
+				SystemProperties.get(SystemProperties.TMP_DIR) + "/" +
+					EmbeddedElasticsearchConnection.JNA_TMP_DIR)
+		);
+
+		embeddedElasticsearchConnection.activate(
+			bundleContext, _elasticsearchConfigurationProperties);
+
+		return embeddedElasticsearchConnection;
+	}
+
+	protected Props createProps() {
+		Props props = Mockito.mock(Props.class);
+
+		Mockito.when(
+			props.get(PropsKeys.LIFERAY_HOME)
+		).thenReturn(
+			_workPath.toString()
+		);
+
+		return props;
+	}
+
+	protected SidecarElasticsearchConnection
+		createSidecarElasticsearchConnection() {
+
+		ElasticsearchConfiguration elasticsearchConfiguration =
+			ConfigurableUtil.createConfigurable(
+				ElasticsearchConfiguration.class,
+				_elasticsearchConfigurationProperties);
+
+		return new SidecarElasticsearchConnection(
+			new Sidecar(
+				getClusterSettingsContext(), elasticsearchConfiguration,
+				createElasticsearchInstancePaths(), "9200-9300",
+				new LocalProcessExecutor(),
+				() -> _TMP_PATH.resolve("lib-process-executor"),
+				getSettingsContributors()));
+	}
+
+	protected void deleteTmpDir() {
+		PathUtil.deleteDir(_workPath);
+	}
+
+	protected SettingsContributor
+		getClusterLoggingThresholdSettingsContributor() {
+
+		return new BaseSettingsContributor(0) {
+
+			@Override
+			public void populate(ClientSettingsHelper clientSettingsHelper) {
+				clientSettingsHelper.put(
+					"cluster.service.slow_task_logging_threshold", "600s");
+			}
+
+		};
+	}
+
+	protected ClusterSettingsContext getClusterSettingsContext() {
+		if (_clusterSettingsContext != null) {
+			return _clusterSettingsContext;
+		}
+
+		return Mockito.mock(ClusterSettingsContext.class);
+	}
+
+	protected SettingsContributor getDiskThresholdSettingsContributor() {
+		return new BaseSettingsContributor(0) {
+
+			@Override
+			public void populate(ClientSettingsHelper clientSettingsHelper) {
+				clientSettingsHelper.put(
+					"cluster.routing.allocation.disk.threshold_enabled",
+					"false");
+			}
+
+		};
+	}
+
+	protected List<SettingsContributor> getSettingsContributors() {
+		return Stream.of(
+			getClusterLoggingThresholdSettingsContributor(),
+			getDiskThresholdSettingsContributor(),
+			getUnicastSettingsContributor()
+		).filter(
+			Objects::nonNull
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	protected SettingsContributor getUnicastSettingsContributor() {
+		if (_clusterSettingsContext != null) {
+			return new UnicastSettingsContributor() {
+				{
+					setClusterSettingsContext(_clusterSettingsContext);
+
+					activate(_elasticsearchConfigurationProperties);
+				}
+			};
+		}
+
+		return null;
+	}
+
+	protected ElasticsearchConnection openElasticsearchConnection() {
+		ElasticsearchConnection elasticsearchConnection =
+			createElasticsearchConnection();
+
+		elasticsearchConnection.connect();
+
+		return elasticsearchConnection;
+	}
+
+	private static final boolean _SIDECAR_REPLACES_EMBEDDED = false;
+
+	private static final Path _TMP_PATH = Paths.get("tmp");
+
+	private ClusterSettingsContext _clusterSettingsContext;
+	private Map<String, Object> _elasticsearchConfigurationProperties =
+		Collections.<String, Object>emptyMap();
+	private ElasticsearchConnection _elasticsearchConnection;
+	private Path _workPath;
+
+}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/ElasticsearchFixture.java
@@ -14,117 +14,66 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.connection;
 
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.Props;
-import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.kernel.util.SystemProperties;
-import com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration;
-import com.liferay.portal.search.elasticsearch7.internal.cluster.ClusterSettingsContext;
-import com.liferay.portal.search.elasticsearch7.internal.cluster.UnicastSettingsContributor;
-import com.liferay.portal.search.elasticsearch7.internal.settings.BaseSettingsContributor;
-import com.liferay.portal.search.elasticsearch7.settings.ClientSettingsHelper;
-import com.liferay.portal.util.FileImpl;
-
-import java.io.File;
 import java.io.IOException;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.FileUtils;
-
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
-import org.elasticsearch.client.ClusterClient;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.client.indices.GetIndexResponse;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
-import org.elasticsearch.common.unit.TimeValue;
-
-import org.mockito.Mockito;
-
-import org.osgi.framework.BundleContext;
 
 /**
  * @author André de Oliveira
  */
 public class ElasticsearchFixture implements ElasticsearchClientResolver {
 
-	public ElasticsearchFixture(Class<?> clazz) {
-		this(getSimpleName(clazz));
+	public ElasticsearchFixture() {
+		this(
+			_elasticsearchConnectionFixtureSingleton.
+				getElasticsearchConnectionFixture(),
+			true);
 	}
 
-	public ElasticsearchFixture(String subdirName) {
-		this(subdirName, Collections.<String, Object>emptyMap());
+	/**
+	 * @deprecated As of Athanasius (7.3.x)
+	 */
+	@Deprecated
+	public ElasticsearchFixture(Class<?> clazz) {
+		this();
 	}
 
 	public ElasticsearchFixture(
-		String subdirName,
-		Map<String, Object> elasticsearchConfigurationProperties) {
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture) {
 
-		_elasticsearchConfigurationProperties =
-			createElasticsearchConfigurationProperties(
-				elasticsearchConfigurationProperties);
-
-		_tmpDirName = "tmp/" + subdirName;
+		this(elasticsearchConnectionFixture, false);
 	}
 
-	public void createNode() throws Exception {
-		deleteTmpDir();
+	public ElasticsearchFixture(
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture,
+		boolean singleton) {
 
-		_embeddedElasticsearchConnection = createElasticsearchConnection();
-
-		ReflectionTestUtil.setFieldValue(
-			_embeddedElasticsearchConnection, "_file", new FileImpl());
+		_elasticsearchConnectionFixture = elasticsearchConnectionFixture;
+		_singleton = singleton;
 	}
 
-	public void destroyNode() throws Exception {
-		if (_embeddedElasticsearchConnection != null) {
-			_embeddedElasticsearchConnection.close();
-		}
-
-		deleteTmpDir();
-	}
-
-	public ClusterHealthResponse getClusterHealthResponse(
-		HealthExpectations healthExpectations) {
-
-		RestHighLevelClient restHighLevelClient = getRestHighLevelClient();
-
-		ClusterClient clusterClient = restHighLevelClient.cluster();
-
-		ClusterHealthRequest clusterHealthRequest = new ClusterHealthRequest();
-
-		clusterHealthRequest.timeout(new TimeValue(10, TimeUnit.MINUTES));
-		clusterHealthRequest.waitForActiveShards(
-			healthExpectations.getActiveShards());
-		clusterHealthRequest.waitForNodes(
-			String.valueOf(healthExpectations.getNumberOfNodes()));
-		clusterHealthRequest.waitForNoRelocatingShards(true);
-		clusterHealthRequest.waitForStatus(healthExpectations.getStatus());
-
-		try {
-			return clusterClient.health(
-				clusterHealthRequest, RequestOptions.DEFAULT);
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
+	/**
+	 * @deprecated As of Athanasius (7.3.x)
+	 */
+	@Deprecated
+	public ElasticsearchFixture(String subdirName) {
+		this();
 	}
 
 	public Map<String, Object> getElasticsearchConfigurationProperties() {
-		return _elasticsearchConfigurationProperties;
+		return _elasticsearchConnectionFixture.
+			getElasticsearchConfigurationProperties();
 	}
 
-	public EmbeddedElasticsearchConnection
-		getEmbeddedElasticsearchConnection() {
-
-		return _embeddedElasticsearchConnection;
+	public ElasticsearchConnection getElasticsearchConnection() {
+		return _elasticsearchConnectionFixture.getElasticsearchConnection();
 	}
 
 	public GetIndexResponse getIndex(String... indices) {
@@ -132,9 +81,7 @@ public class ElasticsearchFixture implements ElasticsearchClientResolver {
 
 		IndicesClient indicesClient = restHighLevelClient.indices();
 
-		GetIndexRequest getIndexRequest = new GetIndexRequest();
-
-		getIndexRequest.indices(indices);
+		GetIndexRequest getIndexRequest = new GetIndexRequest(indices);
 
 		try {
 			return indicesClient.get(getIndexRequest, RequestOptions.DEFAULT);
@@ -146,37 +93,40 @@ public class ElasticsearchFixture implements ElasticsearchClientResolver {
 
 	@Override
 	public RestHighLevelClient getRestHighLevelClient() {
-		return _embeddedElasticsearchConnection.getRestHighLevelClient();
+		return _elasticsearchConnectionFixture.getRestHighLevelClient();
 	}
 
 	@Override
 	public RestHighLevelClient getRestHighLevelClient(String connectionId) {
-		return _embeddedElasticsearchConnection.getRestHighLevelClient();
+		return getRestHighLevelClient();
 	}
 
 	@Override
 	public RestHighLevelClient getRestHighLevelClient(
 		String connectionId, boolean preferLocalCluster) {
 
-		return _embeddedElasticsearchConnection.getRestHighLevelClient();
-	}
-
-	public void setClusterSettingsContext(
-		ClusterSettingsContext clusterSettingsContext) {
-
-		_clusterSettingsContext = clusterSettingsContext;
+		return getRestHighLevelClient();
 	}
 
 	public void setUp() throws Exception {
-		createNode();
+		if (_singleton) {
+			_elasticsearchConnectionFixtureSingleton.start();
+
+			return;
+		}
+
+		_elasticsearchConnectionFixture.createNode();
 	}
 
 	public void tearDown() throws Exception {
-		destroyNode();
+		if (!_singleton) {
+			_elasticsearchConnectionFixture.destroyNode();
+		}
 	}
 
 	public void waitForElasticsearchToStart() {
-		getClusterHealthResponse(
+		ClusterHealthResponseUtil.getClusterHealthResponse(
+			this,
 			new HealthExpectations() {
 				{
 					setActivePrimaryShards(0);
@@ -189,136 +139,42 @@ public class ElasticsearchFixture implements ElasticsearchClientResolver {
 			});
 	}
 
-	protected static String getSimpleName(Class<?> clazz) {
-		while (clazz.isAnonymousClass()) {
-			clazz = clazz.getEnclosingClass();
+	private static final ElasticsearchConnectionFixtureSingleton
+		_elasticsearchConnectionFixtureSingleton =
+			new ElasticsearchConnectionFixtureSingleton();
+
+	private final ElasticsearchConnectionFixture
+		_elasticsearchConnectionFixture;
+	private final boolean _singleton;
+
+	private static class ElasticsearchConnectionFixtureSingleton {
+
+		public void start() {
+			if (!_connected) {
+				_elasticsearchConnectionFixture.createNode();
+
+				_connected = true;
+			}
 		}
 
-		return clazz.getSimpleName();
-	}
+		protected ElasticsearchConnectionFixture
+			getElasticsearchConnectionFixture() {
 
-	protected void addClusterLoggingThresholdContributor(
-		EmbeddedElasticsearchConnection embeddedElasticsearchConnection) {
-
-		embeddedElasticsearchConnection.addSettingsContributor(
-			new BaseSettingsContributor(0) {
-
-				@Override
-				public void populate(
-					ClientSettingsHelper clientSettingsHelper) {
-
-					clientSettingsHelper.put(
-						"cluster.service.slow_task_logging_threshold", "600s");
-				}
-
-			});
-	}
-
-	protected void addDiskThresholdSettingsContributor(
-		EmbeddedElasticsearchConnection embeddedElasticsearchConnection) {
-
-		embeddedElasticsearchConnection.addSettingsContributor(
-			new BaseSettingsContributor(0) {
-
-				@Override
-				public void populate(
-					ClientSettingsHelper clientSettingsHelper) {
-
-					clientSettingsHelper.put(
-						"cluster.routing.allocation.disk.threshold_enabled",
-						"false");
-				}
-
-			});
-	}
-
-	protected void addUnicastSettingsContributor(
-		EmbeddedElasticsearchConnection embeddedElasticsearchConnection) {
-
-		if (_clusterSettingsContext == null) {
-			return;
+			return _elasticsearchConnectionFixture;
 		}
 
-		UnicastSettingsContributor unicastSettingsContributor =
-			new UnicastSettingsContributor() {
-				{
-					setClusterSettingsContext(_clusterSettingsContext);
-
-					activate(_elasticsearchConfigurationProperties);
-				}
-			};
-
-		embeddedElasticsearchConnection.addSettingsContributor(
-			unicastSettingsContributor);
-	}
-
-	protected Map<String, Object> createElasticsearchConfigurationProperties(
-		Map<String, Object> elasticsearchConfigurationProperties) {
-
-		return HashMapBuilder.<String, Object>put(
-			"configurationPid", ElasticsearchConfiguration.class.getName()
-		).put(
-			"httpCORSAllowOrigin", "*"
-		).put(
-			"logExceptionsOnly", false
-		).putAll(
-			elasticsearchConfigurationProperties
-		).build();
-	}
-
-	protected EmbeddedElasticsearchConnection createElasticsearchConnection() {
-		EmbeddedElasticsearchConnection embeddedElasticsearchConnection =
-			new EmbeddedElasticsearchConnection();
-
-		addClusterLoggingThresholdContributor(embeddedElasticsearchConnection);
-		addDiskThresholdSettingsContributor(embeddedElasticsearchConnection);
-		addUnicastSettingsContributor(embeddedElasticsearchConnection);
-
-		Props props = Mockito.mock(Props.class);
-
-		Mockito.when(
-			props.get(PropsKeys.LIFERAY_HOME)
-		).thenReturn(
-			_tmpDirName
-		);
-
-		ClusterSettingsContext clusterSettingsContext = _clusterSettingsContext;
-
-		if (clusterSettingsContext == null) {
-			clusterSettingsContext = Mockito.mock(ClusterSettingsContext.class);
+		private ElasticsearchConnectionFixtureSingleton() {
+			_elasticsearchConnectionFixture =
+				ElasticsearchConnectionFixture.builder(
+				).clusterName(
+					ElasticsearchFixture.class.getSimpleName()
+				).build();
 		}
 
-		embeddedElasticsearchConnection.clusterSettingsContext =
-			clusterSettingsContext;
+		private boolean _connected;
+		private final ElasticsearchConnectionFixture
+			_elasticsearchConnectionFixture;
 
-		embeddedElasticsearchConnection.props = props;
-
-		BundleContext bundleContext = Mockito.mock(BundleContext.class);
-
-		Mockito.when(
-			bundleContext.getDataFile(
-				EmbeddedElasticsearchConnection.JNA_TMP_DIR)
-		).thenReturn(
-			new File(
-				SystemProperties.get(SystemProperties.TMP_DIR) + "/" +
-					EmbeddedElasticsearchConnection.JNA_TMP_DIR)
-		);
-
-		embeddedElasticsearchConnection.activate(
-			bundleContext, _elasticsearchConfigurationProperties);
-
-		embeddedElasticsearchConnection.connect();
-
-		return embeddedElasticsearchConnection;
 	}
-
-	protected void deleteTmpDir() throws Exception {
-		FileUtils.deleteDirectory(new File(_tmpDirName));
-	}
-
-	private ClusterSettingsContext _clusterSettingsContext;
-	private final Map<String, Object> _elasticsearchConfigurationProperties;
-	private EmbeddedElasticsearchConnection _embeddedElasticsearchConnection;
-	private final String _tmpDirName;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/IndexCreator.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/connection/IndexCreator.java
@@ -36,16 +36,7 @@ public class IndexCreator {
 
 		String name = indexName.getName();
 
-		DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(name);
-
-		deleteIndexRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
-
-		try {
-			indicesClient.delete(deleteIndexRequest, RequestOptions.DEFAULT);
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
+		deleteIndex(indicesClient, name);
 
 		CreateIndexRequest createIndexRequest = new CreateIndexRequest(name);
 
@@ -72,6 +63,23 @@ public class IndexCreator {
 		indexCreationHelper.whenIndexCreated(name);
 
 		return new Index(indexName);
+	}
+
+	public void deleteIndex(IndexName indexName) {
+		deleteIndex(getIndicesClient(), indexName.getName());
+	}
+
+	protected void deleteIndex(IndicesClient indicesClient, String name) {
+		DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(name);
+
+		deleteIndexRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
+
+		try {
+			indicesClient.delete(deleteIndexRequest, RequestOptions.DEFAULT);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
 	}
 
 	protected IndexCreationHelper getIndexCreationHelper() {

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/GeoLocationPointFieldTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/GeoLocationPointFieldTest.java
@@ -22,7 +22,6 @@ import com.liferay.portal.search.elasticsearch7.internal.ElasticsearchIndexingFi
 import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchClientResolver;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexCreationHelper;
-import com.liferay.portal.search.elasticsearch7.internal.index.LiferayTypeMappingsConstants;
 import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
@@ -33,10 +32,10 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
-import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
 
@@ -138,9 +137,6 @@ public class GeoLocationPointFieldTest extends BaseIndexingTestCase {
 				"}, \"store\": true, \"type\": \"geo_point\" } } }");
 
 			putMappingRequest.source(source, XContentType.JSON);
-
-			putMappingRequest.type(
-				LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 			RestHighLevelClient restHighLevelClient =
 				_elasticsearchClientResolver.getRestHighLevelClient();

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/GeoLocationPointFieldTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/GeoLocationPointFieldTest.java
@@ -92,7 +92,7 @@ public class GeoLocationPointFieldTest extends BaseIndexingTestCase {
 
 		elasticsearchIndexingFixture.setIndexCreationHelper(
 			new CustomFieldLiferayIndexCreationHelper(
-				elasticsearchIndexingFixture.getElasticsearchFixture()));
+				elasticsearchIndexingFixture.getElasticsearchClientResolver()));
 
 		return elasticsearchIndexingFixture;
 	}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/SingleFieldFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/SingleFieldFixture.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Requests;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilder;
 
@@ -51,7 +52,7 @@ public class SingleFieldFixture {
 	}
 
 	public void indexDocument(String value) {
-		IndexRequest indexRequest = new IndexRequest(_index, _type);
+		IndexRequest indexRequest = Requests.indexRequest(_index);
 
 		indexRequest.source(_field, value);
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIdIndexNameBuilderTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIdIndexNameBuilderTest.java
@@ -18,13 +18,14 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 
 import java.util.Collections;
 
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetIndexResponse;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -38,8 +39,14 @@ public class CompanyIdIndexNameBuilderTest {
 
 	@Before
 	public void setUp() throws Exception {
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+			ElasticsearchConnectionFixture.builder(
+			).clusterName(
+				CompanyIdIndexNameBuilderTest.class.getSimpleName()
+			).build();
+
 		_elasticsearchFixture = new ElasticsearchFixture(
-			CompanyIdIndexNameBuilderTest.class.getSimpleName());
+			elasticsearchConnectionFixture);
 
 		_elasticsearchFixture.setUp();
 	}
@@ -117,8 +124,8 @@ public class CompanyIdIndexNameBuilderTest {
 
 		CompanyIndexFactory companyIndexFactory = new CompanyIndexFactory() {
 			{
-				indexNameBuilder = companyIdIndexNameBuilder;
-				jsonFactory = new JSONFactoryImpl();
+				setIndexNameBuilder(companyIdIndexNameBuilder);
+				setJsonFactory(new JSONFactoryImpl());
 			}
 		};
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryFixture.java
@@ -16,7 +16,7 @@ package com.liferay.portal.search.elasticsearch7.internal.index;
 
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchClientResolver;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
 import com.liferay.portal.search.index.IndexNameBuilder;
 
@@ -28,9 +28,10 @@ import org.elasticsearch.client.RestHighLevelClient;
 public class CompanyIndexFactoryFixture {
 
 	public CompanyIndexFactoryFixture(
-		ElasticsearchFixture elasticsearchFixture, String indexName) {
+		ElasticsearchClientResolver elasticsearchClientResolver,
+		String indexName) {
 
-		_elasticsearchFixture = elasticsearchFixture;
+		_elasticsearchClientResolver = elasticsearchClientResolver;
 		_indexName = indexName;
 	}
 
@@ -38,7 +39,7 @@ public class CompanyIndexFactoryFixture {
 		CompanyIndexFactory companyIndexFactory = getCompanyIndexFactory();
 
 		RestHighLevelClient restHighLevelClient =
-			_elasticsearchFixture.getRestHighLevelClient();
+			_elasticsearchClientResolver.getRestHighLevelClient();
 
 		companyIndexFactory.createIndices(
 			restHighLevelClient.indices(), RandomTestUtil.randomLong());
@@ -48,7 +49,7 @@ public class CompanyIndexFactoryFixture {
 		CompanyIndexFactory companyIndexFactory = getCompanyIndexFactory();
 
 		RestHighLevelClient restHighLevelClient =
-			_elasticsearchFixture.getRestHighLevelClient();
+			_elasticsearchClientResolver.getRestHighLevelClient();
 
 		companyIndexFactory.deleteIndices(
 			restHighLevelClient.indices(), RandomTestUtil.randomLong());
@@ -57,8 +58,8 @@ public class CompanyIndexFactoryFixture {
 	public CompanyIndexFactory getCompanyIndexFactory() {
 		return new CompanyIndexFactory() {
 			{
-				indexNameBuilder = new TestIndexNameBuilder();
-				jsonFactory = new JSONFactoryImpl();
+				setIndexNameBuilder(new TestIndexNameBuilder());
+				setJsonFactory(new JSONFactoryImpl());
 			}
 		};
 	}
@@ -78,7 +79,7 @@ public class CompanyIndexFactoryFixture {
 
 	}
 
-	private final ElasticsearchFixture _elasticsearchFixture;
+	private final ElasticsearchClientResolver _elasticsearchClientResolver;
 	private final String _indexName;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/FieldMappingAssert.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/FieldMappingAssert.java
@@ -19,14 +19,13 @@ import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import java.io.IOException;
 
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
-import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
-import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.indices.GetFieldMappingsRequest;
+import org.elasticsearch.client.indices.GetFieldMappingsResponse;
+import org.elasticsearch.client.indices.GetFieldMappingsResponse.FieldMappingMetaData;
 
 import org.junit.Assert;
 
@@ -53,17 +52,8 @@ public class FieldMappingAssert {
 
 		IdempotentRetryAssert.retryAssert(
 			10, TimeUnit.SECONDS,
-			new Callable<Void>() {
-
-				@Override
-				public Void call() throws Exception {
-					doAssertFieldMappingMetaData(
-						expectedValue, key, field, type, index, indicesClient);
-
-					return null;
-				}
-
-			});
+			() -> doAssertFieldMappingMetaData(
+				expectedValue, key, field, type, index, indicesClient));
 	}
 
 	public static void assertType(
@@ -96,21 +86,19 @@ public class FieldMappingAssert {
 
 		getFieldMappingsRequest.fields(field);
 		getFieldMappingsRequest.indices(index);
-		getFieldMappingsRequest.types(type);
 
 		try {
 			GetFieldMappingsResponse getFieldMappingsResponse =
 				indicesClient.getFieldMapping(
 					getFieldMappingsRequest, RequestOptions.DEFAULT);
 
-			return getFieldMappingsResponse.fieldMappings(index, type, field);
+			return getFieldMappingsResponse.fieldMappings(index, field);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	protected static String getFieldMappingMetaDataValue(
 		FieldMappingMetaData fieldMappingMetaData, String field, String key) {
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayIndexFixture.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/LiferayIndexFixture.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.search.elasticsearch7.internal.index;
 
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
-import com.liferay.portal.search.elasticsearch7.internal.connection.Index;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexCreator;
 import com.liferay.portal.search.elasticsearch7.internal.connection.IndexName;
 
@@ -25,6 +24,7 @@ import java.util.Map;
 
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Requests;
 import org.elasticsearch.client.RestHighLevelClient;
 
 /**
@@ -33,9 +33,18 @@ import org.elasticsearch.client.RestHighLevelClient;
 public class LiferayIndexFixture {
 
 	public LiferayIndexFixture(String subdirName, IndexName indexName) {
-		_indexName = indexName;
+		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture();
 
-		_elasticsearchFixture = new ElasticsearchFixture(subdirName);
+		_elasticsearchFixture = elasticsearchFixture;
+
+		_indexCreator = new IndexCreator() {
+			{
+				setElasticsearchClientResolver(elasticsearchFixture);
+				setLiferayMappingsAddedToIndex(true);
+			}
+		};
+
+		_indexName = indexName;
 	}
 
 	public void assertAnalyzer(String field, String analyzer) throws Exception {
@@ -43,7 +52,7 @@ public class LiferayIndexFixture {
 
 		FieldMappingAssert.assertAnalyzer(
 			analyzer, field, LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE,
-			_index.getName(), restHighLevelClient.indices());
+			_indexName.getName(), restHighLevelClient.indices());
 	}
 
 	public void assertType(String field, String type) throws Exception {
@@ -51,11 +60,7 @@ public class LiferayIndexFixture {
 
 		FieldMappingAssert.assertType(
 			type, field, LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE,
-			_index.getName(), restHighLevelClient.indices());
-	}
-
-	public Index getIndex() {
-		return _index;
+			_indexName.getName(), restHighLevelClient.indices());
 	}
 
 	public RestHighLevelClient getRestHighLevelClient() {
@@ -80,32 +85,21 @@ public class LiferayIndexFixture {
 	public void setUp() throws Exception {
 		_elasticsearchFixture.setUp();
 
-		_index = createIndex();
+		_indexCreator.createIndex(_indexName);
 	}
 
 	public void tearDown() throws Exception {
+		_indexCreator.deleteIndex(_indexName);
+
 		_elasticsearchFixture.tearDown();
 	}
 
-	protected Index createIndex() {
-		IndexCreator indexCreator = new IndexCreator() {
-			{
-				setElasticsearchClientResolver(_elasticsearchFixture);
-				setLiferayMappingsAddedToIndex(true);
-			}
-		};
-
-		return indexCreator.createIndex(_indexName);
-	}
-
 	protected IndexRequest getIndexRequest() {
-		return new IndexRequest(
-			_index.getName(),
-			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
+		return Requests.indexRequest(_indexName.getName());
 	}
 
 	private final ElasticsearchFixture _elasticsearchFixture;
-	private Index _index;
+	private final IndexCreator _indexCreator;
 	private final IndexName _indexName;
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexSearcherLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexSearcherLogExceptionsOnlyTest.java
@@ -19,15 +19,15 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.search.elasticsearch7.internal.ElasticsearchIndexSearcher;
 import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.logging.ExpectedLogTestRule;
 
-import java.util.Map;
+import java.util.Collections;
 import java.util.logging.Level;
 
 import org.junit.Rule;
@@ -57,22 +57,22 @@ public class ElasticsearchIndexSearcherLogExceptionsOnlyTest
 	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.with(
 		ElasticsearchIndexSearcher.class, Level.WARNING);
 
-	protected ElasticsearchFixture createElasticsearchFixture() {
-		Map<String, Object> elasticsearchConfigurationProperties =
-			HashMapBuilder.<String, Object>put(
-				"logExceptionsOnly", true
-			).build();
+	protected ElasticsearchConnectionFixture
+		createElasticsearchConnectionFixture() {
 
-		return new ElasticsearchFixture(
-			ElasticsearchIndexWriterLogExceptionsOnlyTest.class.getSimpleName(),
-			elasticsearchConfigurationProperties);
+		return ElasticsearchConnectionFixture.builder(
+		).clusterName(
+			ElasticsearchIndexWriterLogExceptionsOnlyTest.class.getSimpleName()
+		).elasticsearchConfigurationProperties(
+			Collections.singletonMap("logExceptionsOnly", true)
+		).build();
 	}
 
 	@Override
 	protected IndexingFixture createIndexingFixture() {
 		return LiferayElasticsearchIndexingFixtureFactory.builder(
 		).elasticsearchFixture(
-			createElasticsearchFixture()
+			new ElasticsearchFixture(createElasticsearchConnectionFixture())
 		).build();
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexSearcherLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexSearcherLogExceptionsOnlyTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.elasticsearch7.internal.ElasticsearchIndexSearcher;
 import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
@@ -27,6 +28,7 @@ import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.logging.ExpectedLogTestRule;
 
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,22 +41,21 @@ public class ElasticsearchIndexSearcherLogExceptionsOnlyTest
 
 	@Test
 	public void testExceptionOnlyLoggedWhenQueryMalformedSearch() {
-		expectedLogTestRule.expectMessage(
-			"Failed to execute phase [query], all shards failed");
+		expectedLogTestRule.expectMessage("all shards failed");
 
 		search(createSearchContext(), getMalformedQuery());
 	}
 
 	@Test
 	public void testExceptionOnlyLoggedWhenQueryMalformedSearchCount() {
-		expectedLogTestRule.expectMessage(
-			"Failed to execute phase [query], all shards failed");
+		expectedLogTestRule.expectMessage("all shards failed");
 
 		searchCount(createSearchContext(), getMalformedQuery());
 	}
 
 	@Rule
-	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.none();
+	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.with(
+		ElasticsearchIndexSearcher.class, Level.WARNING);
 
 	protected ElasticsearchFixture createElasticsearchFixture() {
 		Map<String, Object> elasticsearchConfigurationProperties =

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -20,9 +20,9 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.search.elasticsearch7.internal.ElasticsearchIndexWriter;
 import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.document.BulkDocumentRequestExecutorImpl;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
@@ -31,8 +31,8 @@ import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.logging.ExpectedLogTestRule;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 
 import org.hamcrest.CoreMatchers;
@@ -372,22 +372,22 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.with(
 		ElasticsearchIndexWriter.class, Level.WARNING);
 
-	protected ElasticsearchFixture createElasticsearchFixture() {
-		Map<String, Object> elasticsearchConfigurationProperties =
-			HashMapBuilder.<String, Object>put(
-				"logExceptionsOnly", true
-			).build();
+	protected ElasticsearchConnectionFixture
+		createElasticsearchConnectionFixture() {
 
-		return new ElasticsearchFixture(
-			ElasticsearchIndexWriterLogExceptionsOnlyTest.class.getSimpleName(),
-			elasticsearchConfigurationProperties);
+		return ElasticsearchConnectionFixture.builder(
+		).clusterName(
+			ElasticsearchIndexWriterLogExceptionsOnlyTest.class.getSimpleName()
+		).elasticsearchConfigurationProperties(
+			Collections.singletonMap("logExceptionsOnly", true)
+		).build();
 	}
 
 	@Override
 	protected IndexingFixture createIndexingFixture() {
 		return LiferayElasticsearchIndexingFixtureFactory.builder(
 		).elasticsearchFixture(
-			createElasticsearchFixture()
+			new ElasticsearchFixture(createElasticsearchConnectionFixture())
 		).build();
 	}
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
+import org.hamcrest.CoreMatchers;
+
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -118,7 +120,29 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 
 	@Test
 	public void testDeleteDocument() {
-		expectedLogTestRule.expectMessage("no such index");
+		expectedLogTestRule.expectMessage(
+			CoreMatchers.not(CoreMatchers.containsString("no such index")));
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(1);
+
+		IndexWriter indexWriter = getIndexWriter();
+
+		try {
+			indexWriter.deleteDocument(searchContext, "1");
+		}
+		catch (SearchException searchException) {
+		}
+	}
+
+	@Test
+	public void testDeleteDocumentInfoLevel() {
+		expectedLogTestRule.configure(
+			ElasticsearchIndexWriter.class, Level.INFO);
+
+		expectedLogTestRule.expectMessage(
+			CoreMatchers.containsString("no such index"));
 
 		SearchContext searchContext = new SearchContext();
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.elasticsearch7.internal.ElasticsearchIndexWriter;
 import com.liferay.portal.search.elasticsearch7.internal.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.document.BulkDocumentRequestExecutorImpl;
@@ -344,7 +345,8 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Rule
-	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.none();
+	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.with(
+		ElasticsearchIndexWriter.class, Level.WARNING);
 
 	protected ElasticsearchFixture createElasticsearchFixture() {
 		Map<String, Object> elasticsearchConfigurationProperties =

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterClusterRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterClusterRequestTest.java
@@ -20,7 +20,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchClientResolver;
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.cluster.ClusterRequestExecutorFixture;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.cluster.ClusterHealthStatus;
@@ -34,11 +34,11 @@ import com.liferay.portal.search.engine.adapter.cluster.StatsClusterResponse;
 
 import java.io.IOException;
 
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -53,27 +53,32 @@ import org.junit.Test;
 public class ElasticsearchSearchEngineAdapterClusterRequestTest {
 
 	@BeforeClass
-	public static void setUpClass() throws Exception {
-		_elasticsearchFixture = new ElasticsearchFixture(
-			ElasticsearchSearchEngineAdapterClusterRequestTest.class.
-				getSimpleName());
+	public static void setUpClass() {
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+			ElasticsearchConnectionFixture.builder(
+			).clusterName(
+				_CLUSTER_NAME
+			).build();
 
-		_elasticsearchFixture.setUp();
+		elasticsearchConnectionFixture.createNode();
+
+		_elasticsearchConnectionFixture = elasticsearchConnectionFixture;
 	}
 
 	@AfterClass
-	public static void tearDownClass() throws Exception {
-		_elasticsearchFixture.tearDown();
+	public static void tearDownClass() {
+		_elasticsearchConnectionFixture.destroyNode();
 	}
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		setUpJSONFactoryUtil();
 
-		_searchEngineAdapter = createSearchEngineAdapter(_elasticsearchFixture);
+		_searchEngineAdapter = createSearchEngineAdapter(
+			_elasticsearchConnectionFixture);
 
 		RestHighLevelClient restHighLevelClient =
-			_elasticsearchFixture.getRestHighLevelClient();
+			_elasticsearchConnectionFixture.getRestHighLevelClient();
 
 		_indicesClient = restHighLevelClient.indices();
 
@@ -81,111 +86,49 @@ public class ElasticsearchSearchEngineAdapterClusterRequestTest {
 	}
 
 	@After
-	public void tearDown() throws Exception {
+	public void tearDown() {
 		_deleteIndex();
 	}
 
 	@Test
-	public void testExecuteHealthClusterRequest() throws JSONException {
+	public void testExecuteHealthClusterRequest() {
 		HealthClusterRequest healthClusterRequest = new HealthClusterRequest(
 			new String[] {_INDEX_NAME});
 
 		HealthClusterResponse healthClusterResponse =
 			_searchEngineAdapter.execute(healthClusterRequest);
 
-		ClusterHealthStatus clusterHealthStatus =
-			healthClusterResponse.getClusterHealthStatus();
+		assertHealthy(healthClusterResponse.getClusterHealthStatus());
 
-		Assert.assertTrue(
-			clusterHealthStatus.equals(ClusterHealthStatus.GREEN) ||
-			clusterHealthStatus.equals(ClusterHealthStatus.YELLOW));
+		JSONObject jsonObject = createJSONObject(
+			healthClusterResponse.getHealthStatusMessage());
 
-		String healthStatusMessage =
-			healthClusterResponse.getHealthStatusMessage();
+		assertClusterName(jsonObject);
 
-		JSONFactory jsonFactory = new JSONFactoryImpl();
-
-		JSONObject jsonObject = jsonFactory.createJSONObject(
-			healthStatusMessage);
-
-		Assert.assertEquals(
-			"LiferayElasticsearchCluster",
-			jsonObject.getString("cluster_name"));
 		Assert.assertEquals(
 			_ELASTICSEARCH_DEFAULT_NUMBER_OF_SHARDS,
 			jsonObject.getString("active_shards"));
 	}
 
 	@Test
-	public void testExecuteStateClusterRequest() throws JSONException {
+	public void testExecuteStateClusterRequest() {
 		StateClusterRequest stateClusterRequest = new StateClusterRequest(
 			new String[] {_INDEX_NAME});
 
 		StateClusterResponse stateClusterResponse =
 			_searchEngineAdapter.execute(stateClusterRequest);
 
-		String stateMessage = stateClusterResponse.getStateMessage();
-
-		JSONFactory jsonFactory = new JSONFactoryImpl();
-
-		JSONObject jsonObject = jsonFactory.createJSONObject(stateMessage);
-
-		String nodesString = jsonObject.getString("nodes");
-
-		Assert.assertTrue(nodesString.contains("127.0.0.1"));
+		assertNodesContainLocalhost(stateClusterResponse.getStateMessage());
 	}
 
 	@Test
-	public void testExecuteStatsClusterRequest() throws JSONException {
-		StatsClusterRequest statsClusterRequest = new StatsClusterRequest(null);
-
-		StatsClusterResponse statsClusterResponse =
-			_searchEngineAdapter.execute(statsClusterRequest);
-
-		ClusterHealthStatus clusterHealthStatus =
-			statsClusterResponse.getClusterHealthStatus();
-
-		Assert.assertTrue(
-			clusterHealthStatus.equals(ClusterHealthStatus.GREEN) ||
-			clusterHealthStatus.equals(ClusterHealthStatus.YELLOW));
-
-		String statsMessage = statsClusterResponse.getStatsMessage();
-
-		JSONFactory jsonFactory = new JSONFactoryImpl();
-
-		JSONObject jsonObject = jsonFactory.createJSONObject(statsMessage);
-
-		JSONObject indicesJSONObject = jsonObject.getJSONObject("indices");
-
-		Assert.assertEquals("1", indicesJSONObject.getString("count"));
+	public void testExecuteStatsClusterRequest() {
+		doTestExecuteStatsClusterRequest(null);
 	}
 
 	@Test
-	public void testExecuteStatsClusterRequestWithNodeId()
-		throws JSONException {
-
-		StatsClusterRequest statsClusterRequest = new StatsClusterRequest(
-			new String[] {"liferay"});
-
-		StatsClusterResponse statsClusterResponse =
-			_searchEngineAdapter.execute(statsClusterRequest);
-
-		ClusterHealthStatus clusterHealthStatus =
-			statsClusterResponse.getClusterHealthStatus();
-
-		Assert.assertTrue(
-			clusterHealthStatus.equals(ClusterHealthStatus.GREEN) ||
-			clusterHealthStatus.equals(ClusterHealthStatus.YELLOW));
-
-		String statsMessage = statsClusterResponse.getStatsMessage();
-
-		JSONFactory jsonFactory = new JSONFactoryImpl();
-
-		JSONObject jsonObject = jsonFactory.createJSONObject(statsMessage);
-
-		JSONObject indicesJSONObject = jsonObject.getJSONObject("indices");
-
-		Assert.assertEquals("1", indicesJSONObject.getString("count"));
+	public void testExecuteStatsClusterRequestWithNodeId() {
+		doTestExecuteStatsClusterRequest(new String[] {"liferay"});
 	}
 
 	protected static ClusterRequestExecutor createClusterRequestExecutor(
@@ -212,6 +155,54 @@ public class ElasticsearchSearchEngineAdapterClusterRequestTest {
 					createClusterRequestExecutor(elasticsearchClientResolver));
 			}
 		};
+	}
+
+	protected void assertClusterName(JSONObject jsonObject) {
+		Assert.assertEquals(
+			_CLUSTER_NAME, jsonObject.getString("cluster_name"));
+	}
+
+	protected void assertHealthy(ClusterHealthStatus clusterHealthStatus) {
+		Assert.assertTrue(
+			clusterHealthStatus.equals(ClusterHealthStatus.GREEN) ||
+			clusterHealthStatus.equals(ClusterHealthStatus.YELLOW));
+	}
+
+	protected void assertNodesContainLocalhost(String message) {
+		JSONObject jsonObject = createJSONObject(message);
+
+		String nodesString = jsonObject.getString("nodes");
+
+		Assert.assertTrue(nodesString.contains("127.0.0.1"));
+	}
+
+	protected void assertOneIndex(String message) {
+		JSONObject jsonObject = createJSONObject(message);
+
+		JSONObject indicesJSONObject = jsonObject.getJSONObject("indices");
+
+		Assert.assertEquals("1", indicesJSONObject.getString("count"));
+	}
+
+	protected JSONObject createJSONObject(String message) {
+		try {
+			return _jsonFactory.createJSONObject(message);
+		}
+		catch (JSONException jsonException) {
+			throw new RuntimeException(jsonException);
+		}
+	}
+
+	protected void doTestExecuteStatsClusterRequest(String[] nodeIds) {
+		StatsClusterRequest statsClusterRequest = new StatsClusterRequest(
+			nodeIds);
+
+		StatsClusterResponse statsClusterResponse =
+			_searchEngineAdapter.execute(statsClusterRequest);
+
+		assertHealthy(statsClusterResponse.getClusterHealthStatus());
+
+		assertOneIndex(statsClusterResponse.getStatsMessage());
 	}
 
 	protected void setUpJSONFactoryUtil() {
@@ -244,11 +235,16 @@ public class ElasticsearchSearchEngineAdapterClusterRequestTest {
 		}
 	}
 
+	private static final String _CLUSTER_NAME =
+		ElasticsearchSearchEngineAdapterClusterRequestTest.class.
+			getSimpleName();
+
 	private static final String _ELASTICSEARCH_DEFAULT_NUMBER_OF_SHARDS = "1";
 
 	private static final String _INDEX_NAME = "test_request_index";
 
-	private static ElasticsearchFixture _elasticsearchFixture;
+	private static ElasticsearchConnectionFixture
+		_elasticsearchConnectionFixture;
 
 	private IndicesClient _indicesClient;
 	private final JSONFactory _jsonFactory = new JSONFactoryImpl();

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterIndexRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterIndexRequestTest.java
@@ -66,7 +66,6 @@ import java.util.Map;
 
 import org.apache.http.util.EntityUtils;
 
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
@@ -80,6 +79,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -102,8 +102,7 @@ public class ElasticsearchSearchEngineAdapterIndexRequestTest {
 	public static void setUpClass() throws Exception {
 		setUpJSONFactoryUtil();
 
-		_elasticsearchFixture = new ElasticsearchFixture(
-			ElasticsearchSearchEngineAdapterIndexRequestTest.class);
+		_elasticsearchFixture = new ElasticsearchFixture();
 
 		_elasticsearchFixture.setUp();
 
@@ -708,10 +707,10 @@ public class ElasticsearchSearchEngineAdapterIndexRequestTest {
 	}
 
 	private void _createIndex(String indexName) {
-		org.elasticsearch.action.admin.indices.create.CreateIndexRequest
+		org.elasticsearch.client.indices.CreateIndexRequest
 			elasticsearchCreateIndexRequest =
-				new org.elasticsearch.action.admin.indices.create.
-					CreateIndexRequest(indexName);
+				new org.elasticsearch.client.indices.CreateIndexRequest(
+					indexName);
 
 		try {
 			_indicesClient.create(
@@ -769,9 +768,7 @@ public class ElasticsearchSearchEngineAdapterIndexRequestTest {
 	}
 
 	private boolean _indiciesExists(String indexName) {
-		GetIndexRequest getIndexRequest = new GetIndexRequest();
-
-		getIndexRequest.indices(indexName);
+		GetIndexRequest getIndexRequest = new GetIndexRequest(indexName);
 
 		try {
 			return _indicesClient.exists(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/cluster/StatsClusterRequestExecutorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/cluster/StatsClusterRequestExecutorTest.java
@@ -17,7 +17,7 @@ package com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.engine.adapter.cluster.StatsClusterRequest;
 import com.liferay.portal.search.engine.adapter.cluster.StatsClusterResponse;
 
@@ -35,15 +35,20 @@ public class StatsClusterRequestExecutorTest {
 	public void setUp() throws Exception {
 		setUpJSONFactoryUtil();
 
-		_elasticsearchFixture = new ElasticsearchFixture(
-			StatsClusterRequestExecutorTest.class.getSimpleName());
+		ElasticsearchConnectionFixture elasticsearchConnectionFixture =
+			ElasticsearchConnectionFixture.builder(
+			).clusterName(
+				StatsClusterRequestExecutorTest.class.getSimpleName()
+			).build();
 
-		_elasticsearchFixture.setUp();
+		elasticsearchConnectionFixture.createNode();
+
+		_elasticsearchConnectionFixture = elasticsearchConnectionFixture;
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		_elasticsearchFixture.tearDown();
+		_elasticsearchConnectionFixture.destroyNode();
 	}
 
 	@Test
@@ -54,7 +59,8 @@ public class StatsClusterRequestExecutorTest {
 		StatsClusterRequestExecutorImpl statsClusterRequestExecutorImpl =
 			new StatsClusterRequestExecutorImpl() {
 				{
-					setElasticsearchClientResolver(_elasticsearchFixture);
+					setElasticsearchClientResolver(
+						_elasticsearchConnectionFixture);
 					setClusterHealthStatusTranslator(
 						new ClusterHealthStatusTranslatorImpl());
 				}
@@ -76,7 +82,7 @@ public class StatsClusterRequestExecutorTest {
 
 	private static final String _NODE_ID = "liferay";
 
-	private ElasticsearchFixture _elasticsearchFixture;
+	private ElasticsearchConnectionFixture _elasticsearchConnectionFixture;
 	private final JSONFactory _jsonFactory = new JSONFactoryImpl();
 
 }

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
@@ -228,7 +228,6 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		Assert.assertEquals(
 			expectedRefreshPolicy, indexRequest.getRefreshPolicy());
 		Assert.assertEquals(_INDEX_NAME, indexRequest.index());
-		Assert.assertEquals(_MAPPING_NAME, indexRequest.type());
 		Assert.assertEquals(id, indexRequest.id());
 
 		String source = XContentHelper.convertToJson(

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/GetMappingIndexRequestExecutorTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/index/GetMappingIndexRequestExecutorTest.java
@@ -17,7 +17,7 @@ package com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter.
 import com.liferay.portal.search.elasticsearch7.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.engine.adapter.index.GetMappingIndexRequest;
 
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsRequest;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -31,8 +31,7 @@ public class GetMappingIndexRequestExecutorTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_elasticsearchFixture = new ElasticsearchFixture(
-			GetMappingIndexRequestExecutorTest.class.getSimpleName());
+		_elasticsearchFixture = new ElasticsearchFixture();
 
 		_elasticsearchFixture.setUp();
 	}
@@ -61,8 +60,6 @@ public class GetMappingIndexRequestExecutorTest {
 
 		Assert.assertArrayEquals(
 			new String[] {_INDEX_NAME}, getMappingsRequest.indices());
-		Assert.assertArrayEquals(
-			new String[] {_MAPPING_NAME}, getMappingsRequest.types());
 	}
 
 	private static final String _INDEX_NAME = "test_request_index";

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/build.gradle
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	testCompile project(":apps:portal-search:portal-search")
 	testCompile project(":apps:portal-search:portal-search-test-util")
 	testCompile project(":core:petra:petra-concurrent")
+	testCompile project(":core:petra:petra-function")
 	testCompile project(":core:petra:petra-lang")
 	testCompile project(":core:petra:petra-memory")
 	testCompile project(":core:petra:petra-nio")

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/logging/SolrIndexSearcherLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/logging/SolrIndexSearcherLogExceptionsOnlyTest.java
@@ -19,12 +19,14 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.solr7.internal.SolrIndexSearcher;
 import com.liferay.portal.search.solr7.internal.SolrIndexingFixture;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.logging.ExpectedLogTestRule;
 
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,7 +52,8 @@ public class SolrIndexSearcherLogExceptionsOnlyTest
 	}
 
 	@Rule
-	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.none();
+	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.with(
+		SolrIndexSearcher.class, Level.WARNING);
 
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {

--- a/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/logging/SolrIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-solr7/portal-search-solr7-impl/src/test/java/com/liferay/portal/search/solr7/internal/logging/SolrIndexWriterLogExceptionsOnlyTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.solr7.internal.SolrIndexWriter;
 import com.liferay.portal.search.solr7.internal.SolrIndexingFixture;
 import com.liferay.portal.search.solr7.internal.search.engine.adapter.document.BulkDocumentRequestExecutorImpl;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
@@ -42,6 +43,7 @@ import org.junit.Test;
 public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@After
+	@Override
 	public void tearDown() throws Exception {
 	}
 
@@ -149,8 +151,7 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 
 	@Test
 	public void testDeleteEntityDocuments() {
-		expectedLogTestRule.expectMessage(
-			"Problem accessing /solr/liferay/" + _COLLECTION_NAME);
+		expectedLogTestRule.expectMessage("java.lang.NullPointerException");
 
 		IndexWriter indexWriter = getIndexWriter();
 
@@ -274,7 +275,8 @@ public class SolrIndexWriterLogExceptionsOnlyTest extends BaseIndexingTestCase {
 	}
 
 	@Rule
-	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.none();
+	public ExpectedLogTestRule expectedLogTestRule = ExpectedLogTestRule.with(
+		SolrIndexWriter.class, Level.WARNING);
 
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {

--- a/modules/apps/portal-search/portal-search-test-util/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search Test Utilities
 Bundle-SymbolicName: com.liferay.portal.search.test.util
-Bundle-Version: 4.4.2
+Bundle-Version: 4.5.0
 Export-Package:\
 	com.liferay.portal.search.test.util,\
 	com.liferay.portal.search.test.util.logging

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/background/task/BaseReindexSingleIndexerBackgroundTaskExecutorTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/background/task/BaseReindexSingleIndexerBackgroundTaskExecutorTestCase.java
@@ -51,20 +51,31 @@ public abstract class BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
 	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 
-		_companyId = RandomTestUtil.randomLong();
+		long companyId = RandomTestUtil.randomLong();
+
+		setUpBackgroundTask(companyId);
 
 		setUpIndexerRegistry();
 
-		setUpBackgroundTask();
+		SearchEngineFixture searchEngineFixture = getSearchEngineFixture();
 
-		setUpSearchEngineFixture();
+		searchEngineFixture.setUp();
 
-		setUpSearchEngineHelper();
+		SearchEngineHelper searchEngineHelper = new SearchEngineHelperImpl();
+
+		searchEngineHelper.setSearchEngine(
+			"test", searchEngineFixture.getSearchEngine());
+
+		_companyId = companyId;
+		_searchEngineFixture = searchEngineFixture;
+		_searchEngineHelper = searchEngineHelper;
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		searchEngineFixture.tearDown();
+		if (_searchEngineFixture != null) {
+			_searchEngineFixture.tearDown();
+		}
 	}
 
 	@Test
@@ -83,7 +94,7 @@ public abstract class BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
 
 	protected String getIndexName() {
 		IndexNameBuilder indexNameBuilder =
-			searchEngineFixture.getIndexNameBuilder();
+			_searchEngineFixture.getIndexNameBuilder();
 
 		return indexNameBuilder.getIndexName(_companyId);
 	}
@@ -105,7 +116,7 @@ public abstract class BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
 
 	protected abstract SearchEngineFixture getSearchEngineFixture();
 
-	protected void setUpBackgroundTask() {
+	protected void setUpBackgroundTask(long companyId) {
 		Mockito.when(
 			_backgroundTask.getTaskContextMap()
 		).thenReturn(
@@ -114,7 +125,7 @@ public abstract class BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
 				RandomTestUtil.randomString()
 			).put(
 				ReindexBackgroundTaskConstants.COMPANY_IDS,
-				new long[] {_companyId}
+				new long[] {companyId}
 			).build()
 		);
 	}
@@ -126,21 +137,6 @@ public abstract class BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
 			_indexer
 		);
 	}
-
-	protected void setUpSearchEngineFixture() throws Exception {
-		searchEngineFixture = getSearchEngineFixture();
-
-		searchEngineFixture.setUp();
-	}
-
-	protected void setUpSearchEngineHelper() {
-		_searchEngineHelper = new SearchEngineHelperImpl();
-
-		_searchEngineHelper.setSearchEngine(
-			"test", searchEngineFixture.getSearchEngine());
-	}
-
-	protected SearchEngineFixture searchEngineFixture;
 
 	@Mock
 	private BackgroundTask _backgroundTask;
@@ -159,6 +155,7 @@ public abstract class BaseReindexSingleIndexerBackgroundTaskExecutorTestCase {
 	@Mock
 	private ReindexStatusMessageSender _reindexStatusMessageSender;
 
+	private SearchEngineFixture _searchEngineFixture;
 	private SearchEngineHelper _searchEngineHelper;
 
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
@@ -102,6 +102,10 @@ public abstract class BaseIndexingTestCase {
 	public static void tearDownClassBaseIndexingTestCase() throws Exception {
 		_documentFixture.tearDown();
 
+		if (_indexingFixture == null) {
+			return;
+		}
+
 		if (_indexingFixture.isSearchEngineAvailable()) {
 			_indexingFixture.tearDown();
 		}
@@ -124,6 +128,10 @@ public abstract class BaseIndexingTestCase {
 
 	@After
 	public void tearDown() throws Exception {
+		if (_indexingFixture == null) {
+			return;
+		}
+
 		if (!_indexingFixture.isSearchEngineAvailable()) {
 			return;
 		}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
@@ -41,10 +41,12 @@ import com.liferay.portal.search.aggregation.pipeline.PipelineAggregation;
 import com.liferay.portal.search.document.DocumentBuilder;
 import com.liferay.portal.search.document.DocumentBuilderFactory;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
 import com.liferay.portal.search.geolocation.GeoBuilders;
 import com.liferay.portal.search.highlight.Highlights;
 import com.liferay.portal.search.internal.aggregation.AggregationsImpl;
 import com.liferay.portal.search.internal.document.DocumentBuilderFactoryImpl;
+import com.liferay.portal.search.internal.filter.ComplexQueryPartBuilderFactoryImpl;
 import com.liferay.portal.search.internal.geolocation.GeoBuildersImpl;
 import com.liferay.portal.search.internal.highlight.HighlightsImpl;
 import com.liferay.portal.search.internal.legacy.searcher.SearchRequestBuilderImpl;
@@ -328,6 +330,9 @@ public abstract class BaseIndexingTestCase {
 	protected final AggregationFixture aggregationFixture =
 		new AggregationFixture();
 	protected final Aggregations aggregations = new AggregationsImpl();
+	protected final ComplexQueryPartBuilderFactory
+		complexQueryPartBuilderFactory =
+			new ComplexQueryPartBuilderFactoryImpl();
 	protected DocumentBuilderFactory documentBuilderFactory =
 		new DocumentBuilderFactoryImpl();
 	protected final GeoBuilders geoBuilders = new GeoBuildersImpl();

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/logging/ExpectedLogTestRule.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/logging/ExpectedLogTestRule.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.CaptureHandler;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -41,6 +42,10 @@ public class ExpectedLogTestRule implements TestRule {
 
 	public static ExpectedLogTestRule none() {
 		return new ExpectedLogTestRule(null, null);
+	}
+
+	public static ExpectedLogTestRule with(Class<?> clazz, Level level) {
+		return new ExpectedLogTestRule(clazz.getName(), level);
 	}
 
 	public static ExpectedLogTestRule with(String name, Level level) {
@@ -95,16 +100,11 @@ public class ExpectedLogTestRule implements TestRule {
 	}
 
 	public void verify() {
-		if (_captureHandler == null) {
-			return;
-		}
-
 		if (!_matcherBuilder.isAnythingExpected()) {
 			return;
 		}
 
-		Assert.assertThat(
-			_captureHandler.getLogRecords(), _matcherBuilder.build());
+		Assert.assertThat(getLogRecords(), _matcherBuilder.build());
 	}
 
 	protected void closeCaptureHandler() {
@@ -115,6 +115,14 @@ public class ExpectedLogTestRule implements TestRule {
 		_captureHandler.close();
 
 		_captureHandler = null;
+	}
+
+	protected List<LogRecord> getLogRecords() {
+		if (_captureHandler != null) {
+			return _captureHandler.getLogRecords();
+		}
+
+		return Collections.emptyList();
 	}
 
 	protected void openCaptureHandler(String name, Level level) {

--- a/modules/apps/portal-search/portal-search-test-util/src/main/resources/com/liferay/portal/search/test/util/logging/packageinfo
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/resources/com/liferay/portal/search/test/util/logging/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
_Elasticsearch 7: make unit tests compatible with Sidecar (decouple Embedded away)_
https://issues.liferay.com/browse/LPS-113450

_Flaky: com.liferay.bookmarks.search.test: "expected:<1> but was:<0>"_
https://issues.liferay.com/browse/LPS-111384

_ExpectedLogTestRule.none() always passes, should instead assert logs clean_
https://issues.liferay.com/browse/LPS-113837

_PortalLogAssertorTest fails on ERROR log from document deletion attempted after company index already deleted_
https://issues.liferay.com/browse/LPS-113354
